### PR TITLE
Add minimum dependencies version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,11 +16,11 @@ include = ["LICENSE", "README.md"]
 
 [tool.poetry.dependencies]
 python = "^3.7"
-fastapi = "*"
-uvicorn = "*"
-aioredis = {version = "*", optional = true}
-aiomcache = {version = "*", optional = true}
-python-dateutil = "*"
+fastapi = ">=0.63.0"
+uvicorn = ">=0.12.0"
+aioredis = {version = ">=1.3.1", optional = true}
+aiomcache = {version = ">=0.6.0", optional = true}
+python-dateutil = ">=2.8.1"
 
 [tool.poetry.dev-dependencies]
 flake8 = "*"


### PR DESCRIPTION
At the current moment, it's impossible to install this package via poetry because of a min version conflict with the extras specified in `pyproject.toml`. It's probably best to set a minimum/explicit version and then have Dependabot tests against new updates instead of having `*`