### PR TITLE
Encode args and kwargs

### DIFF
--- a/fastapi_cache/decorator.py
+++ b/fastapi_cache/decorator.py
@@ -38,7 +38,7 @@ def cache(
             backend = FastAPICache.get_backend()
 
             cache_key = key_builder(
-                func, namespace, request=request, response=response, args=args, kwargs=copy_kwargs
+                func, namespace, request=request, response=response, args=coder.encode(args), kwargs=coder.encode(copy_kwargs)
             )
             ttl, ret = await backend.get_with_ttl(cache_key)
             if not request:

--- a/fastapi_cache/decorator.py
+++ b/fastapi_cache/decorator.py
@@ -38,7 +38,12 @@ def cache(
             backend = FastAPICache.get_backend()
 
             cache_key = key_builder(
-                func, namespace, request=request, response=response, args=coder.encode(args), kwargs=coder.encode(copy_kwargs)
+                func,
+                namespace,
+                request=request,
+                response=response,
+                args=coder.encode(args),
+                kwargs=coder.encode(copy_kwargs),
             )
             ttl, ret = await backend.get_with_ttl(cache_key)
             if not request:


### PR DESCRIPTION
The `args` and `kwargs` from the decorated are imported as a string directly which causes issues when using ORMs like SQLAlchemy that use instances of Sessions are have a different string representation. These values should be encoded via the coder.