### PR TITLE
fix bug by adding utf-8

### DIFF
--- a/fastapi_cache/key_builder.py
+++ b/fastapi_cache/key_builder.py
@@ -19,7 +19,7 @@ def default_key_builder(
     cache_key = (
         prefix
         + hashlib.md5(  # nosec:B303
-            f"{func.__module__}:{func.__name__}:{args}:{kwargs}"
+            f"{func.__module__}:{func.__name__}:{args}:{kwargs}".encode('utf-8')
         ).hexdigest()
     )
     return cache_key


### PR DESCRIPTION
fix  File "c:\Users\jackm\GitHub\pool-api\wvenv\lib\site-packages\fastapi_cache\key_builder.py", line 21, in default_key_builder
    + hashlib.md5(  # nosec:B303
TypeError: Unicode-objects must be encoded before hashing
#19 