### PR TITLE
This fixes #24.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.1
 
+### 0.1.5
+- Fix setting expire for redis (#24)
+- Update expire key
+
 ### 0.1.4
 
 - Fix default expire for memcached. (#13)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,10 @@
 
 ## 0.1
 
-### 0.1.5
-- Fix setting expire for redis (#24)
-- Update expire key
-
 ### 0.1.4
 
+- Fix setting expire for redis (#24)
+- Update expire key
 - Fix default expire for memcached. (#13)
 - Update default key builder. (#12)
 

--- a/fastapi_cache/backends/redis.py
+++ b/fastapi_cache/backends/redis.py
@@ -19,7 +19,7 @@ class RedisBackend(Backend):
         return await self.redis.get(key)
 
     async def set(self, key: str, value: str, expire: int = None):
-        return await self.redis.set(key, value, expire=expire)
+        return await self.redis.set(key, value, ex=expire)
 
     async def clear(self, namespace: str = None, key: str = None) -> int:
         if namespace:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fastapi-cache2"
-version = "0.1.4"
+version = "0.1.4.1"
 description = "Cache for FastAPI"
 authors = ["long2ice <long2ice@gmail.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Looking at aioredis library, the client.py keyword for set is now 'ex', not 'expire'. Tested this fix and fast-cache now works without issue.