### PR TITLE
This fixes #26. 

### DIFF
--- a/fastapi_cache/decorator.py
+++ b/fastapi_cache/decorator.py
@@ -38,7 +38,7 @@ def cache(
             backend = FastAPICache.get_backend()
 
             cache_key = key_builder(
-                func, namespace, request=request, response=response, args=args, kwargs=copy_kwargs
+                func, namespace, request=request, response=response, coder.encode(args=args), coder.encode(kwargs=copy_kwargs)
             )
             ttl, ret = await backend.get_with_ttl(cache_key)
             if not request:


### PR DESCRIPTION
When assigning cache_key with key_builder, args/kwargs must be encoded with the coder so a unique id for a specific endpoint and does not create multiple per request. Issue is now resolved and requests are now being pulled from cache after setting the key and then getting it.

Changelog and version updated to 0.1.7.