### PR TITLE
Added event handlers and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1.1.1
         with:
-          virtualenvs-create: false
+          virtualenvs-create: true
+      - name: Run tests
+        run: poetry run pytest
       - name: CI
         run: make ci

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -14,7 +14,9 @@ jobs:
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1.1.1
         with:
-          virtualenvs-create: false
+          virtualenvs-create: true
+      - name: Run tests
+        run: poetry run pytest
       - name: Build dists
         run: make build
       - name: Pypi Publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.1
 
+### 0.1.7
+
+- Added event handling for new key and existing key
+- Added tests for custom_key_builder and event handling
+
 ### 0.1.6
 
 - Fix redis cache.

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@
 ## Features
 
 - Support `redis` and `memcache` and `in-memory` backends.
-- Easily integration with `fastapi`.
+- Easily integrate with `fastapi`.
 - Support http cache like `ETag` and `Cache-Control`.
+- Event handlers for when a new key is added and existing key called
 
 ## Requirements
 
@@ -131,6 +132,39 @@ async def index(request: Request, response: Response):
 ### InMemoryBackend
 
 `InMemoryBackend` store cache data in memory and use lazy delete, which mean if you don't access it after cached, it will not delete automatically.
+
+### Event handling
+
+For the events `new_key` and `existing_key` you can pass in a custom handler. By default there are no handlers.
+
+*Via a decorator:*
+
+```python
+@FastAPICache.on_event("existing_key")
+def exists_in_cache(func, *args, **kwargs):
+    print("Existing key")
+    return None
+
+@FastAPICache.on_event("new_key")
+def new_in_cache(func, *args, **kwargs):
+    print("New key set")
+    return None
+```
+
+*Via a class method:*
+
+```python
+def exists_in_cache(func, *args, **kwargs):
+    print("Existing key")
+    return None
+
+def new_in_cache(func, *args, **kwargs):
+    print("New key set")
+    return None
+
+FastAPICache.set_on_existing_key(exists_in_cache)
+FastAPICache.set_on_new_key(new_in_cache)
+```
 
 ## License
 

--- a/examples/main.py
+++ b/examples/main.py
@@ -10,8 +10,17 @@ from fastapi_cache.decorator import cache
 
 app = FastAPI()
 
-ret = 0
+@FastAPICache.on_event("existing_key")
+def exists_in_cache(func, *args, **kwargs):
+    print("Existing key")
+    return None
 
+@FastAPICache.on_event("new_key")
+def new_in_cache(func, *args, **kwargs):
+    print("New key set")
+    return None
+
+ret = 0
 
 @cache(namespace="test", expire=1)
 async def get_ret():

--- a/fastapi_cache/__init__.py
+++ b/fastapi_cache/__init__.py
@@ -11,6 +11,9 @@ class FastAPICache:
     _init = False
     _coder = None
     _key_builder = None
+    _on_existing_key = None
+    _on_new_key = None
+    _event_handlers = {}
 
     @classmethod
     def init(
@@ -19,7 +22,7 @@ class FastAPICache:
         prefix: str = "",
         expire: int = None,
         coder: Coder = JsonCoder,
-        key_builder: Callable = default_key_builder,
+        key_builder: Callable = default_key_builder
     ):
         if cls._init:
             return
@@ -29,6 +32,19 @@ class FastAPICache:
         cls._expire = expire
         cls._coder = coder
         cls._key_builder = key_builder
+        cls._event_handlers = {}
+
+    @classmethod
+    def on_event(cls, type):
+        def registerhandler(handler):
+            if type == "existing_key":
+                cls.set_on_existing_key(handler)
+            elif type == "new_key":
+                cls.set_on_new_key(handler)
+            else:
+                raise Exception("Unsupported type for on_event")
+            return handler
+        return registerhandler
 
     @classmethod
     def get_backend(cls):
@@ -50,6 +66,22 @@ class FastAPICache:
     @classmethod
     def get_key_builder(cls):
         return cls._key_builder
+
+    @classmethod
+    def get_on_existing_key(cls):
+        return cls._on_existing_key
+
+    @classmethod
+    def get_on_new_key(cls):
+        return cls._on_new_key
+
+    @classmethod
+    def set_on_existing_key(cls, handler):
+        cls._on_existing_key = handler
+
+    @classmethod
+    def set_on_new_key(cls, handler):
+        cls._on_new_key = handler
 
     @classmethod
     async def clear(cls, namespace: str = None, key: str = None):

--- a/poetry.lock
+++ b/poetry.lock
@@ -22,6 +22,24 @@ typing-extensions = "*"
 hiredis = ["hiredis (>=1.0)"]
 
 [[package]]
+name = "anyio"
+version = "3.3.0"
+description = "High level compatibility layer for multiple asynchronous event loop implementations"
+category = "main"
+optional = false
+python-versions = ">=3.6.2"
+
+[package.dependencies]
+idna = ">=2.8"
+sniffio = ">=1.1"
+typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
+
+[package.extras]
+doc = ["sphinx-rtd-theme", "sphinx-autodoc-typehints (>=1.2.0)"]
+test = ["coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "pytest (>=6.0)", "pytest-mock (>=3.6.1)", "trustme", "uvloop (<0.15)", "mock (>=4)", "uvloop (>=0.15)"]
+trio = ["trio (>=0.16)"]
+
+[[package]]
 name = "appdirs"
 version = "1.4.4"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
@@ -55,7 +73,7 @@ python-versions = ">=3.5.3"
 name = "atomicwrites"
 version = "1.4.0"
 description = "Atomic file writes."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
@@ -63,7 +81,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 name = "attrs"
 version = "21.2.0"
 description = "Classes Without Boilerplate"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
@@ -113,6 +131,25 @@ python2 = ["typed-ast (>=1.4.2)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
+name = "certifi"
+version = "2021.5.30"
+description = "Python package for providing Mozilla's CA Bundle."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "charset-normalizer"
+version = "2.0.4"
+description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
+category = "main"
+optional = false
+python-versions = ">=3.5.0"
+
+[package.extras]
+unicode_backport = ["unicodedata2"]
+
+[[package]]
 name = "click"
 version = "8.0.1"
 description = "Composable command line interface toolkit"
@@ -131,6 +168,23 @@ description = "Cross-platform colored terminal text."
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "fakeredis"
+version = "1.6.0"
+description = "Fake implementation of redis API for testing purposes."
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+redis = "<3.6.0"
+six = ">=1.12"
+sortedcontainers = "*"
+
+[package.extras]
+aioredis = ["aioredis"]
+lua = ["lupa"]
 
 [[package]]
 name = "fastapi"
@@ -196,6 +250,49 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "httpcore"
+version = "0.13.6"
+description = "A minimal low-level HTTP client."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+anyio = ">=3.0.0,<4.0.0"
+h11 = ">=0.11,<0.13"
+sniffio = ">=1.0.0,<2.0.0"
+
+[package.extras]
+http2 = ["h2 (>=3,<5)"]
+
+[[package]]
+name = "httpx"
+version = "0.19.0"
+description = "The next generation HTTP client."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+certifi = "*"
+charset-normalizer = "*"
+httpcore = ">=0.13.3,<0.14.0"
+rfc3986 = {version = ">=1.3,<2", extras = ["idna2008"]}
+sniffio = "*"
+
+[package.extras]
+brotli = ["brotlicffi", "brotli"]
+http2 = ["h2 (>=3,<5)"]
+
+[[package]]
+name = "idna"
+version = "3.2"
+description = "Internationalized Domain Names in Applications (IDNA)"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
 name = "importlib-metadata"
 version = "4.8.0"
 description = "Read metadata from Python packages"
@@ -216,7 +313,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 name = "iniconfig"
 version = "1.1.1"
 description = "iniconfig: brain-dead simple config-ini parsing"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -254,7 +351,7 @@ python-versions = "*"
 name = "packaging"
 version = "21.0"
 description = "Core utilities for Python packages"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -281,7 +378,7 @@ python-versions = ">=2.6"
 name = "pluggy"
 version = "0.13.1"
 description = "plugin and hook calling mechanisms for python"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
@@ -295,7 +392,7 @@ dev = ["pre-commit", "tox"]
 name = "py"
 version = "1.10.0"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
@@ -334,7 +431,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 name = "pyparsing"
 version = "2.4.7"
 description = "Python parsing module"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
@@ -342,7 +439,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 name = "pytest"
 version = "6.2.4"
 description = "pytest: simple powerful testing with Python"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -359,6 +456,20 @@ toml = "*"
 
 [package.extras]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
+
+[[package]]
+name = "pytest-asyncio"
+version = "0.15.1"
+description = "Pytest support for asyncio."
+category = "main"
+optional = false
+python-versions = ">= 3.6"
+
+[package.dependencies]
+pytest = ">=5.4.0"
+
+[package.extras]
+testing = ["coverage", "hypothesis (>=5.7.1)"]
 
 [[package]]
 name = "python-dateutil"
@@ -380,12 +491,55 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
 [[package]]
+name = "redis"
+version = "3.5.3"
+description = "Python client for Redis key-value store"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[package.extras]
+hiredis = ["hiredis (>=0.1.3)"]
+
+[[package]]
 name = "regex"
 version = "2021.8.28"
 description = "Alternative regular expression module, to replace re."
 category = "dev"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "requests"
+version = "2.26.0"
+description = "Python HTTP for Humans."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+charset-normalizer = {version = ">=2.0.0,<2.1.0", markers = "python_version >= \"3\""}
+idna = {version = ">=2.5,<4", markers = "python_version >= \"3\""}
+urllib3 = ">=1.21.1,<1.27"
+
+[package.extras]
+socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
+use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
+
+[[package]]
+name = "rfc3986"
+version = "1.5.0"
+description = "Validating URI References per RFC 3986"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+idna = {version = "*", optional = true, markers = "extra == \"idna2008\""}
+
+[package.extras]
+idna2008 = ["idna"]
 
 [[package]]
 name = "six"
@@ -402,6 +556,22 @@ description = "A pure Python implementation of a sliding window memory map manag
 category = "dev"
 optional = false
 python-versions = ">=3.5"
+
+[[package]]
+name = "sniffio"
+version = "1.2.0"
+description = "Sniff out which async library your code is running under"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+description = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
+category = "main"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "starlette"
@@ -430,7 +600,7 @@ pbr = ">=2.0.0,<2.1.0 || >2.1.0"
 name = "toml"
 version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
@@ -457,6 +627,19 @@ description = "Backported and Experimental Type Hints for Python 3.5+"
 category = "main"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "urllib3"
+version = "1.26.6"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+
+[package.extras]
+brotli = ["brotlipy (>=0.6.0)"]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "uvicorn"
@@ -495,7 +678,7 @@ redis = ["aioredis"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "ef5ffb1be6e352b2dcd5c657fb7bb307545907236e6389124a53203ecd5cc506"
+content-hash = "b14ea0af34eb68ce2effae97b17d9b0b931e4ce29308c28eedeaebd60d1b3cdb"
 
 [metadata.files]
 aiomcache = [
@@ -505,6 +688,10 @@ aiomcache = [
 aioredis = [
     {file = "aioredis-2.0.0-py3-none-any.whl", hash = "sha256:9921d68a3df5c5cdb0d5b49ad4fc88a4cfdd60c108325df4f0066e8410c55ffb"},
     {file = "aioredis-2.0.0.tar.gz", hash = "sha256:3a2de4b614e6a5f8e104238924294dc4e811aefbe17ddf52c04a93cbf06e67db"},
+]
+anyio = [
+    {file = "anyio-3.3.0-py3-none-any.whl", hash = "sha256:929a6852074397afe1d989002aa96d457e3e1e5441357c60d03e7eea0e65e1b0"},
+    {file = "anyio-3.3.0.tar.gz", hash = "sha256:ae57a67583e5ff8b4af47666ff5651c3732d45fd26c929253748e796af860374"},
 ]
 appdirs = [
     {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
@@ -534,6 +721,14 @@ black = [
     {file = "black-21.7b0-py3-none-any.whl", hash = "sha256:1c7aa6ada8ee864db745b22790a32f94b2795c253a75d6d9b5e439ff10d23116"},
     {file = "black-21.7b0.tar.gz", hash = "sha256:c8373c6491de9362e39271630b65b964607bc5c79c83783547d76c839b3aa219"},
 ]
+certifi = [
+    {file = "certifi-2021.5.30-py2.py3-none-any.whl", hash = "sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8"},
+    {file = "certifi-2021.5.30.tar.gz", hash = "sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee"},
+]
+charset-normalizer = [
+    {file = "charset-normalizer-2.0.4.tar.gz", hash = "sha256:f23667ebe1084be45f6ae0538e4a5a865206544097e4e8bbcacf42cd02a348f3"},
+    {file = "charset_normalizer-2.0.4-py3-none-any.whl", hash = "sha256:0c8911edd15d19223366a194a513099a302055a962bca2cec0f54b8b63175d8b"},
+]
 click = [
     {file = "click-8.0.1-py3-none-any.whl", hash = "sha256:fba402a4a47334742d782209a7c79bc448911afe1149d07bdabdf480b3e2f4b6"},
     {file = "click-8.0.1.tar.gz", hash = "sha256:8c04c11192119b1ef78ea049e0a6f0463e4c48ef00a30160c704337586f3ad7a"},
@@ -541,6 +736,10 @@ click = [
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
+]
+fakeredis = [
+    {file = "fakeredis-1.6.0-py3-none-any.whl", hash = "sha256:3449b306f3a85102b28f8180c24722ef966fcb1e3c744758b6f635ec80321a5c"},
+    {file = "fakeredis-1.6.0.tar.gz", hash = "sha256:11ccfc9769d718d37e45b382e64a6ba02586b622afa0371a6bd85766d72255f3"},
 ]
 fastapi = [
     {file = "fastapi-0.68.1-py3-none-any.whl", hash = "sha256:94d2820906c36b9b8303796fb7271337ec89c74223229e3cfcf056b5a7d59e23"},
@@ -561,6 +760,18 @@ gitpython = [
 h11 = [
     {file = "h11-0.12.0-py3-none-any.whl", hash = "sha256:36a3cb8c0a032f56e2da7084577878a035d3b61d104230d4bd49c0c6b555a9c6"},
     {file = "h11-0.12.0.tar.gz", hash = "sha256:47222cb6067e4a307d535814917cd98fd0a57b6788ce715755fa2b6c28b56042"},
+]
+httpcore = [
+    {file = "httpcore-0.13.6-py3-none-any.whl", hash = "sha256:db4c0dcb8323494d01b8c6d812d80091a31e520033e7b0120883d6f52da649ff"},
+    {file = "httpcore-0.13.6.tar.gz", hash = "sha256:b0d16f0012ec88d8cc848f5a55f8a03158405f4bca02ee49bc4ca2c1fda49f3e"},
+]
+httpx = [
+    {file = "httpx-0.19.0-py3-none-any.whl", hash = "sha256:9bd728a6c5ec0a9e243932a9983d57d3cc4a87bb4f554e1360fce407f78f9435"},
+    {file = "httpx-0.19.0.tar.gz", hash = "sha256:92ecd2c00c688b529eda11cedb15161eaf02dee9116712f621c70d9a40b2cdd0"},
+]
+idna = [
+    {file = "idna-3.2-py3-none-any.whl", hash = "sha256:14475042e284991034cb48e06f6851428fb14c4dc953acd9be9a5e95c7b6dd7a"},
+    {file = "idna-3.2.tar.gz", hash = "sha256:467fbad99067910785144ce333826c71fb0e63a425657295239737f7ecd125f3"},
 ]
 importlib-metadata = [
     {file = "importlib_metadata-4.8.0-py3-none-any.whl", hash = "sha256:7108c0c93872d7e9312c69d2f8e625fac7da59dc9a32475336bb99bc83815497"},
@@ -642,6 +853,10 @@ pytest = [
     {file = "pytest-6.2.4-py3-none-any.whl", hash = "sha256:91ef2131a9bd6be8f76f1f08eac5c5317221d6ad1e143ae03894b862e8976890"},
     {file = "pytest-6.2.4.tar.gz", hash = "sha256:50bcad0a0b9c5a72c8e4e7c9855a3ad496ca6a881a3641b4260605450772c54b"},
 ]
+pytest-asyncio = [
+    {file = "pytest-asyncio-0.15.1.tar.gz", hash = "sha256:2564ceb9612bbd560d19ca4b41347b54e7835c2f792c504f698e05395ed63f6f"},
+    {file = "pytest_asyncio-0.15.1-py3-none-any.whl", hash = "sha256:3042bcdf1c5d978f6b74d96a151c4cfb9dcece65006198389ccd7e6c60eb1eea"},
+]
 python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
     {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
@@ -676,6 +891,10 @@ pyyaml = [
     {file = "PyYAML-5.4.1-cp39-cp39-win32.whl", hash = "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10"},
     {file = "PyYAML-5.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db"},
     {file = "PyYAML-5.4.1.tar.gz", hash = "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"},
+]
+redis = [
+    {file = "redis-3.5.3-py2.py3-none-any.whl", hash = "sha256:432b788c4530cfe16d8d943a09d40ca6c16149727e4afe8c2c9d5580c59d9f24"},
+    {file = "redis-3.5.3.tar.gz", hash = "sha256:0e7e0cfca8660dea8b7d5cd8c4f6c5e29e11f31158c0b0ae91a397f00e5a05a2"},
 ]
 regex = [
     {file = "regex-2021.8.28-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9d05ad5367c90814099000442b2125535e9d77581855b9bee8780f1b41f2b1a2"},
@@ -720,6 +939,14 @@ regex = [
     {file = "regex-2021.8.28-cp39-cp39-win_amd64.whl", hash = "sha256:610b690b406653c84b7cb6091facb3033500ee81089867ee7d59e675f9ca2b73"},
     {file = "regex-2021.8.28.tar.gz", hash = "sha256:f585cbbeecb35f35609edccb95efd95a3e35824cd7752b586503f7e6087303f1"},
 ]
+requests = [
+    {file = "requests-2.26.0-py2.py3-none-any.whl", hash = "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24"},
+    {file = "requests-2.26.0.tar.gz", hash = "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"},
+]
+rfc3986 = [
+    {file = "rfc3986-1.5.0-py2.py3-none-any.whl", hash = "sha256:a86d6e1f5b1dc238b218b012df0aa79409667bb209e58da56d0b94704e712a97"},
+    {file = "rfc3986-1.5.0.tar.gz", hash = "sha256:270aaf10d87d0d4e095063c65bf3ddbc6ee3d0b226328ce21e036f946e421835"},
+]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
@@ -727,6 +954,14 @@ six = [
 smmap = [
     {file = "smmap-4.0.0-py2.py3-none-any.whl", hash = "sha256:a9a7479e4c572e2e775c404dcd3080c8dc49f39918c2cf74913d30c4c478e3c2"},
     {file = "smmap-4.0.0.tar.gz", hash = "sha256:7e65386bd122d45405ddf795637b7f7d2b532e7e401d46bbe3fb49b9986d5182"},
+]
+sniffio = [
+    {file = "sniffio-1.2.0-py3-none-any.whl", hash = "sha256:471b71698eac1c2112a40ce2752bb2f4a4814c22a54a3eed3676bc0f5ca9f663"},
+    {file = "sniffio-1.2.0.tar.gz", hash = "sha256:c4666eecec1d3f50960c6bdf61ab7bc350648da6c126e3cf6898d8cd4ddcd3de"},
+]
+sortedcontainers = [
+    {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
+    {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
 ]
 starlette = [
     {file = "starlette-0.14.2-py3-none-any.whl", hash = "sha256:3c8e48e52736b3161e34c9f0e8153b4f32ec5d8995a3ee1d59410d92f75162ed"},
@@ -780,6 +1015,10 @@ typing-extensions = [
     {file = "typing_extensions-3.10.0.0-py2-none-any.whl", hash = "sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497"},
     {file = "typing_extensions-3.10.0.0-py3-none-any.whl", hash = "sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84"},
     {file = "typing_extensions-3.10.0.0.tar.gz", hash = "sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342"},
+]
+urllib3 = [
+    {file = "urllib3-1.26.6-py2.py3-none-any.whl", hash = "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4"},
+    {file = "urllib3-1.26.6.tar.gz", hash = "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"},
 ]
 uvicorn = [
     {file = "uvicorn-0.15.0-py3-none-any.whl", hash = "sha256:17f898c64c71a2640514d4089da2689e5db1ce5d4086c2d53699bf99513421c1"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,10 @@ uvicorn = "*"
 aioredis = {version = "^2.0", optional = true}
 aiomcache = {version = "*", optional = true}
 python-dateutil = "*"
+fakeredis = "^1.6.0"
+pytest-asyncio = "^0.15.1"
+requests = "^2.26.0"
+httpx = "^0.19.0"
 
 [tool.poetry.dev-dependencies]
 flake8 = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fastapi-cache2"
-version = "0.1.6"
+version = "0.1.7"
 description = "Cache for FastAPI"
 authors = ["long2ice <long2ice@gmail.com>"]
 license = "Apache-2.0"

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -1,2 +1,43 @@
+import pytest
+import fakeredis.aioredis
+from fastapi_cache import FastAPICache
+from fastapi_cache.decorator import cache
+from fastapi_cache.backends.redis import RedisBackend
+from fastapi import FastAPI
+from httpx import AsyncClient
+
+app = FastAPI()
+
+# Create dummy aioredis instance for testing
+fake_redis = fakeredis.aioredis.FakeRedis()
+
+# Initiate FastAPICache with dummy aioredis instance
+FastAPICache.init(RedisBackend(fake_redis), prefix="fastapi-cache")
+
+# Create example custom key builder
+def example_key_builder(func, *args, **kwarg):
+    return "my-custom-cache-key"
+
+# Create example route with cache decorator, including custom key builder
+@app.get("/")
+@cache(key_builder=example_key_builder)
+async def example():
+    return 1
+
+# Asynchronous test
+@pytest.mark.asyncio
+async def test_custom_key_builder_redis():
+    """
+    Tests if custom_key_builder creates key value in Redis
+    """
+
+    # Call "/"" route and await response 
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        response = await ac.get("/")
+
+    # Check if key exists in Redis instance
+    key_exists = await fake_redis.exists("my-custom-cache-key")
+    assert key_exists
+
 def test_default_key_builder():
     return 1

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -31,7 +31,7 @@ async def test_custom_key_builder_redis():
     Tests if custom_key_builder creates key value in Redis
     """
 
-    # Call "/"" route and await response 
+    # Call "/" route and await response 
     async with AsyncClient(app=app, base_url="http://test") as ac:
         response = await ac.get("/")
 

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,0 +1,67 @@
+import pytest
+import fakeredis.aioredis
+from fastapi_cache import FastAPICache
+from fastapi_cache.decorator import cache
+from fastapi_cache.backends.redis import RedisBackend
+from unittest.mock import patch
+from fastapi import FastAPI
+from httpx import AsyncClient
+
+app = FastAPI()
+
+# Create dummy aioredis instance for testing
+fake_redis = fakeredis.aioredis.FakeRedis()
+
+# Initiate FastAPICache with dummy aioredis instance
+FastAPICache.init(RedisBackend(fake_redis), prefix="fastapi-cache")
+
+# Create example route with cache decorator
+@app.get("/")
+@cache()
+async def example():
+    return 1
+
+# Create example function for on_new_key
+def on_new_key(func, *args, **kwargs):
+    return None
+
+# Create example function for on_existing_key
+def on_existing_key(func, *args, **kwargs):
+    return None
+
+# Asynchronous test
+@pytest.mark.asyncio
+@patch("tests.test_handlers.on_existing_key")
+@patch("tests.test_handlers.on_new_key")
+# Patches are applied bottom up - https://docs.python.org/3/library/unittest.mock.html#quick-guide
+async def test_event_handlers_triggered(mock_new_key_function, mock_existing_key_function):
+    """
+    Tests if event handler functions are triggered at the correct part of the caching lifecycle
+    """
+    # Clear the cache
+    FastAPICache.clear
+
+    # Set functions for new and existing key
+    FastAPICache.set_on_new_key(mock_new_key_function)
+    FastAPICache.set_on_existing_key(mock_existing_key_function)
+
+    # Call "/"" route and await response. Creating a new key
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        response = await ac.get("/")
+
+    # Check new key function called
+    mock_new_key_function.assert_called()
+    # Check existing key function not called
+    mock_existing_key_function.assert_not_called()
+
+    # Reset mock for new key function
+    mock_new_key_function.reset_mock()
+
+    # Call "/"" route and await response. Key already exists
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        response = await ac.get("/")
+
+    # Check existing key function called
+    mock_existing_key_function.assert_called()
+    # Check new key function not called
+    mock_new_key_function.assert_not_called()

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -45,7 +45,7 @@ async def test_event_handlers_triggered(mock_new_key_function, mock_existing_key
     FastAPICache.set_on_new_key(mock_new_key_function)
     FastAPICache.set_on_existing_key(mock_existing_key_function)
 
-    # Call "/"" route and await response. Creating a new key
+    # Call "/" route and await response. Creating a new key
     async with AsyncClient(app=app, base_url="http://test") as ac:
         response = await ac.get("/")
 
@@ -57,7 +57,7 @@ async def test_event_handlers_triggered(mock_new_key_function, mock_existing_key
     # Reset mock for new key function
     mock_new_key_function.reset_mock()
 
-    # Call "/"" route and await response. Key already exists
+    # Call "/" route and await response. Key already exists
     async with AsyncClient(app=app, base_url="http://test") as ac:
         response = await ac.get("/")
 


### PR DESCRIPTION
**Summary:**
Added optional custom event handlers for new_key and existing_key. Also added tests to cover the event handlers and custom key builder

**Example**
For the events `new_key` and `existing_key` you can pass in a custom handler. By default there are no handlers.

*Via a decorator:*

```python
@FastAPICache.on_event("existing_key")
def exists_in_cache(func, *args, **kwargs):
    print("Existing key")
    return None
@FastAPICache.on_event("new_key")
def new_in_cache(func, *args, **kwargs):
    print("New key set")
    return None
```

*Via a class method:*

```python
def exists_in_cache(func, *args, **kwargs):
    print("Existing key")
    return None
def new_in_cache(func, *args, **kwargs):
    print("New key set")
    return None
FastAPICache.set_on_existing_key(exists_in_cache)
FastAPICache.set_on_new_key(new_in_cache)
```