### PR TITLE
bugfix: '+' is more prior than 'or'

### DIFF
--- a/fastapi_cache/backends/inmemory.py
+++ b/fastapi_cache/backends/inmemory.py
@@ -43,7 +43,7 @@ class InMemoryBackend(Backend):
 
     async def set(self, key: str, value: str, expire: int = None):
         async with self._lock:
-            self._store[key] = Value(value, self._now + expire or 0)
+            self._store[key] = Value(value, self._now + (expire or 0))
 
     async def clear(self, namespace: str = None, key: str = None) -> int:
         count = 0


### PR DESCRIPTION
Means when call set function not set expire param, will cause int + None error