### PR TITLE
Feature/return model on cache

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -536,6 +536,21 @@ tomli = ">=1.0.0"
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
 
 [[package]]
+name = "pytest-asyncio"
+version = "0.18.3"
+description = "Pytest support for asyncio"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+pytest = ">=6.1.0"
+typing-extensions = {version = ">=3.7.2", markers = "python_version < \"3.8\""}
+
+[package.extras]
+testing = ["coverage (==6.2)", "hypothesis (>=5.7.1)", "flaky (>=3.5.0)", "mypy (==0.931)", "pytest-trio (>=0.7.0)"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
@@ -709,7 +724,7 @@ redis = ["aioredis"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "87166e8e761098376d7351cbcea72719247cc12f1e2910ae9646d5a923d112cf"
+content-hash = "cbfb065981b0435c1d8877b74ac8e961c278566d54f0f9379697e9b3f5dcde3a"
 
 [metadata.files]
 aiobotocore = [
@@ -1143,6 +1158,11 @@ pyparsing = [
 pytest = [
     {file = "pytest-7.1.1-py3-none-any.whl", hash = "sha256:92f723789a8fdd7180b6b06483874feca4c48a5c76968e03bb3e7f806a1869ea"},
     {file = "pytest-7.1.1.tar.gz", hash = "sha256:841132caef6b1ad17a9afde46dc4f6cfa59a05f9555aae5151f73bdf2820ca63"},
+]
+pytest-asyncio = [
+    {file = "pytest-asyncio-0.18.3.tar.gz", hash = "sha256:7659bdb0a9eb9c6e3ef992eef11a2b3e69697800ad02fb06374a210d85b29f91"},
+    {file = "pytest_asyncio-0.18.3-1-py3-none-any.whl", hash = "sha256:16cf40bdf2b4fb7fc8e4b82bd05ce3fbcd454cbf7b92afc445fe299dabb88213"},
+    {file = "pytest_asyncio-0.18.3-py3-none-any.whl", hash = "sha256:8fafa6c52161addfd41ee7ab35f11836c5a16ec208f93ee388f752bea3493a84"},
 ]
 python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ isort = "*"
 black = "*"
 pytest = "*"
 bandit = "*"
+pytest-asyncio = "^0.18.3"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+
+from fastapi_cache import FastAPICache
+from fastapi_cache.backends.inmemory import InMemoryBackend
+
+
+@pytest.fixture(autouse=True)
+def setup():
+    FastAPICache.init(InMemoryBackend(), prefix="fastapi-cache-test")

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -1,2 +1,30 @@
+import pytest
+from pydantic import BaseModel
+
+from fastapi_cache.decorator import cache
+
+
 def test_default_key_builder():
     return 1
+
+
+class MyModel(BaseModel):
+    name: str
+    age: int
+
+
+@cache(expire=3600)
+async def get_model() -> MyModel:
+    return MyModel(name="John", age=30)
+
+
+@pytest.mark.asyncio
+async def test_get_model_returns_a_model():
+
+    # First time, when is not cached, will return whatever the function returns
+    assert isinstance(await get_model(), MyModel)
+
+    # Second time, when is cached, will return the cached value, parsing it to a model
+    assert isinstance(await get_model(), MyModel)
+
+


### PR DESCRIPTION
The cache currently always returns a json, which is fine for most api routes/functions. But given that this is based in fastapi, and fastapi in pydantic, makes sense to parse the return object to a model (if possible).

I added a failing test, and what solves it.

@long2ice let me know what you think.