### PR TITLE
Fix redis package in some places

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ or
 ### Quick Start
 
 ```python
-import aioredis
+import redis.asyncio as redis
+from redis.asyncio.connection import ConnectionPool
 from fastapi import FastAPI
 from starlette.requests import Request
 from starlette.responses import Response
@@ -76,8 +77,9 @@ async def index(request: Request, response: Response):
 
 @app.on_event("startup")
 async def startup():
-    redis =  aioredis.from_url("redis://localhost", encoding="utf8", decode_responses=True)
-    FastAPICache.init(RedisBackend(redis), prefix="fastapi-cache")
+    pool = ConnectionPool.from_url(url="redis://localhost")
+    r = redis.Redis(connection_pool=pool)
+    FastAPICache.init(RedisBackend(r), prefix="fastapi-cache")
 
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"
 
 [tool.poetry.extras]
-redis = ["aioredis"]
+redis = ["redis"]
 memcache = ["aiomcache"]
 dynamodb = ["aiobotocore"]
 all = ["redis","aiomcache"]


### PR DESCRIPTION
Hello!

README.md example usedold aioredis, I have updated it to use redis-py. 
Also, the poetry extra dependency for 'redis' had aioredis and not normal redis, leading to aioredis being installed on 
```sh
pip install "fastapi-cache2[redis]"
```
