### PR TITLE
fix: :bug: make FastAPICache.clear clear whole prefix when namespace is None

### DIFF
--- a/fastapi_cache/__init__.py
+++ b/fastapi_cache/__init__.py
@@ -60,5 +60,5 @@ class FastAPICache:
 
     @classmethod
     async def clear(cls, namespace: str = None, key: str = None):
-        namespace = cls._prefix + ":" + namespace if namespace else None
+        namespace = cls._prefix + (":" + namespace if namespace else "")
         return await cls._backend.clear(namespace, key)


### PR DESCRIPTION
Hi guys, didn't find any contributing guide, so feel free to tell me if what I propose is not on the right format.

## Description

This PR aims to make the `FastAPICache.clear` method work when not providing any namespace.

## Initial Issue

Caching a function without any namespace, it is not possible to clear it using the FastAPICache method.
```python
@cache()
def my_func():
   ...

# will do nothing
FastAPICache.clear()

# will try to delete "my-fastapi-prefix:my-fastapi-prefix", so it will do nothing.
FastAPICache.clear(FastAPICache._prefix)
```

## Expected behavior

Calling FastAPICache.clear without any namespace should clear the whole FastAPICache's prefix.
```python
@cache()
def my_func():
   ...

# should clear everything with my FastAPICache._prefix.
FastAPICache.clear()
```

## Testing

There are no test suite setup for now in your project, so I wasn't able to unit-test it, so I had to do some manual testing.