### PR TITLE
fix: :bug: FastAPICache.clear | do not hardcode namespace if a key is provided

### DIFF
--- a/fastapi_cache/__init__.py
+++ b/fastapi_cache/__init__.py
@@ -60,5 +60,6 @@ class FastAPICache:
 
     @classmethod
     async def clear(cls, namespace: str = None, key: str = None):
-        namespace = cls._prefix + (":" + namespace if namespace else "")
+        if key is None or namespace is not None:
+            namespace = cls._prefix + (":" + namespace if namespace else "")
         return await cls._backend.clear(namespace, key)


### PR DESCRIPTION
Hi again!
Following my previous PR #72 

Here is a fix we need to avoid breaking the `inmemory` and `redis` backends.

## Explanation

both `InMemoryBackend` and `RedisBackend` clear methods have the following code:
```python3
if namespace:
    do_something()
elif key:
    do_something_else()
```

My last fix, since it was always setting a value for `namespace` was breaking the case `namespace is None and key is not None` since it would NEVER go to the `elif key`.

## Testing

again, no test suite being configured, I had to manually test it. Here is a (dirty) testing file you can use, feel free to add it to your test suite when adding tests.

```python3
def clear(namespace=None, key=None):
    prefix = "prefix"
    if key is None or namespace is not None:
        namespace = prefix + (":" + namespace if namespace else "")
    return namespace, key


res = clear()
assert res == ("prefix", None), res

res = clear(namespace="mock")
assert res == ("prefix:mock", None), res

res = clear(key="mock")
assert clear(key="mock") == (None, "mock"), res

res = clear(namespace="mock", key="mock")
assert res == ("prefix:mock", "mock"), res
```