### PR TITLE
Add ability to use async function for key_builder

### DIFF
--- a/fastapi_cache/decorator.py
+++ b/fastapi_cache/decorator.py
@@ -47,9 +47,25 @@ def cache(
             key_builder = key_builder or FastAPICache.get_key_builder()
             backend = FastAPICache.get_backend()
 
-            cache_key = key_builder(
-                func, namespace, request=request, response=response, args=args, kwargs=copy_kwargs
-            )
+            if inspect.iscoroutinefunction(key_builder):
+                cache_key = await key_builder(
+                    func,
+                    namespace,
+                    request=request,
+                    response=response,
+                    args=args,
+                    kwargs=copy_kwargs
+                )
+            else:
+                cache_key = key_builder(
+                    func,
+                    namespace,
+                    request=request,
+                    response=response,
+                    args=args,
+                    kwargs=copy_kwargs
+                )
+
             ttl, ret = await backend.get_with_ttl(cache_key)
             if not request:
                 if ret is not None:


### PR DESCRIPTION
This PR makes it possible to use async function for the key_builder (useful for example when the route function is async, and it is needed to extract the body of the request, which would require `body = await request.body()`)