### PR TITLE
add backend:Diskcache

### DIFF
--- a/fastapi_cache/backends/diskcache.py
+++ b/fastapi_cache/backends/diskcache.py
@@ -1,0 +1,72 @@
+from itertools import groupby
+from operator import itemgetter
+from time import time
+from typing import Tuple, Union
+
+from fastapi_cache.backends import Backend
+
+from diskcache import Cache, FanoutCache
+
+
+class DiskCacheBackend(Backend):
+    def __init__(self, diskcache: Union[Cache, FanoutCache]):
+        self.cache = diskcache
+
+    async def get_with_ttl(self, key: str) -> Tuple[int, str]:
+        with self.cache.transact(retry=True):
+            value, ttl = self.cache.get(key, expire_time=True, retry=True)  # type: ignore
+            return ttl, value
+
+    async def get(self, key) -> str:
+        return self.cache.get(key, retry=True)  # type: ignore
+
+    async def set(self, key: str, value: str, expire: Union[int, None] = None):
+        return self.cache.set(key, value, expire=expire, retry=True)
+
+    async def clear(self, namespace: Union[str, None] = None, key: Union[str, None] = None) -> int:
+        if namespace:
+            if isinstance(self.cache, FanoutCache):
+                caches = self.cache._shards
+                result = [self._clear(cache, namespace) for cache in caches]
+                return sum(result)
+            return self._clear(self.cache, namespace)
+
+        elif key:
+            if self.cache.delete(key, retry=True):
+                return 1
+            else:
+                return 0
+        return 0
+
+    def _clear(self, cache: Cache, namespace: str) -> int:
+        keys = {
+            key: cache.disk.put(key)
+            for key in cache.iterkeys()
+            if isinstance(key, str) and key.startswith(namespace)
+        }
+
+        with cache._transact(retry=True) as (sql, cleanup):
+            now = time()
+            rows = sql(
+                "select rowid, filename, key, raw from Cache"
+                " where key in ?"
+                " and (expire_time is null or expire_time > ?",
+                (f"({','.join(keys.keys())})", now),
+            ).fetchall()
+
+            selected_rows = [
+                (rowid, filename) for rowid, filename, key, raw in rows if keys[key] == raw
+            ]
+
+            if not selected_rows:
+                return 0
+
+            sorted_rows = sorted(selected_rows, key=itemgetter(1))
+            for filename, group in groupby(sorted_rows, key=itemgetter(1)):
+                sql(
+                    "delete from Cache where rowid in ?",
+                    (f"({','.join(str(rowid) for rowid, _ in group)})",),
+                )
+                cleanup(filename)
+
+            return len(sorted_rows)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,7 @@ homepage = "https://github.com/long2ice/fastapi-cache"
 repository = "https://github.com/long2ice/fastapi-cache.git"
 documentation = "https://github.com/long2ice/fastapi-cache"
 keywords = ["fastapi", "cache", "caching"]
-packages = [
-    { include = "fastapi_cache" }
-]
+packages = [{ include = "fastapi_cache" }]
 include = ["LICENSE", "README.md"]
 
 [tool.poetry.dependencies]
@@ -22,7 +20,7 @@ redis = { version = "^4.2.0rc1", optional = true }
 aiomcache = { version = "*", optional = true }
 pendulum = "*"
 aiobotocore = { version = "^1.4.1", optional = true }
-diskcache = "^5.4.0"
+diskcache = { version = "^5.4.0", optional = true }
 
 [tool.poetry.dev-dependencies]
 flake8 = "*"
@@ -38,7 +36,8 @@ build-backend = "poetry.masonry.api"
 redis = ["redis"]
 memcache = ["aiomcache"]
 dynamodb = ["aiobotocore"]
-all = ["redis", "aiomcache", "aiobotocore"]
+diskcache = ["diskcache"]
+all = ["redis", "aiomcache", "aiobotocore", "diskcache"]
 
 [tool.black]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ redis = { version = "^4.2.0rc1", optional = true }
 aiomcache = { version = "*", optional = true }
 pendulum = "*"
 aiobotocore = { version = "^1.4.1", optional = true }
+diskcache = "^5.4.0"
 
 [tool.poetry.dev-dependencies]
 flake8 = "*"


### PR DESCRIPTION
diskcache: [github](https://github.com/grantjenks/python-diskcache)

I think `diskcache` is a good library to use in the absence of an installable backend.
`diskcache` is a library that uses local drive and `sqlite`, and is not much different from `redis`, the results of its own benchmark of `diskcache`.

I expect it to work normally, but I haven't checked it properly yet. In particular, `namespace` in the `clear` method is not a feature supported by `diskcache`, so it is written somewhat inefficiently. I don't know if using `tag` can solve it in a similar way.

In addition, `diskcache` does not support asynchronous operations. Threads can be used to simulate asynchronous tasks, but they were not used because they were not good methods.

There may be a lot of deficiencies in this PR that I write for the second time. I would appreciate it if you could consider that.