### PR TITLE
fix: example coroutine object is not iterable

### DIFF
--- a/examples/redis/main.py
+++ b/examples/redis/main.py
@@ -43,9 +43,9 @@ async def get_data(request: Request, response: Response):
 
 @app.get("/blocking")
 @cache(namespace="test", expire=10)
-def blocking():
+async def blocking():
     time.sleep(5)
-    return dict(ret=get_ret())
+    return dict(ret=await get_ret())
 
 
 @app.get("/datetime")


### PR DESCRIPTION
No more info to reproduce the #80 issue, but found this one.