### PR TITLE
Transparent passthrough in the event of cache backend connection issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 0.2.1
 
 - Support cache jinja2 template response.
+- Transparently handle backend connection failures.
 
 ### 0.2.0
 


### PR DESCRIPTION
Currently if using the cache decorator on a method with a FastAPI path operation decorator, if there are any connection issues to a backend (e.g. Redis) an unhandled exception from the backend will cause a HTTP 500 - meaning cache backend uptime becomes a requirement for API functionality.
This PR sets a better default - if cache backend connectivity fails, pass the request through as you would if the decorator isn't there (reimplementation of #14)

@long2ice @mkdir700 could you have a look please? Hopefully a quick merge for you but this failure mode is a big blocker for me to use and evangelise library this more widely. As per #99 a new release would be awesome too!