### PR TITLE
Passthrough for any type of backend exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.2
 
+### 0.2.1
+- Fix picklecoder
+- Fix connection failure transparency
+- Add Cache-Control and ETag on first response
+
 ### 0.2.0
 
 - Make `request` and `response` optional.

--- a/fastapi_cache/decorator.py
+++ b/fastapi_cache/decorator.py
@@ -125,7 +125,7 @@ def cache(
                 )
             try:
                 ttl, ret = await backend.get_with_ttl(cache_key)
-            except ConnectionError:
+            except Exception:
                 ttl, ret = 0, None
             if not request:
                 if ret is not None:
@@ -133,7 +133,7 @@ def cache(
                 ret = await ensure_async_func(*args, **kwargs)
                 try:
                     await backend.set(cache_key, coder.encode(ret), expire)
-                except ConnectionError:
+                except Exception:
                     pass
                 return ret
 
@@ -156,7 +156,7 @@ def cache(
 
             try:
                 await backend.set(cache_key, encoded_ret, expire)
-            except ConnectionError:
+            except Exception:
                 pass
 
             response.headers["Cache-Control"] = f"max-age={expire}"


### PR DESCRIPTION
Turns out this exception handling wasn't good enough - backends throw more than ConnectionErrors 

- redis-py throws many types all ultimately subclasses of Exception - https://github.com/redis/redis-py/blob/v4.4.2/redis/exceptions.py#L4-L8
- aiomcache does something similar - https://github.com/aio-libs/aiomcache/blob/v0.8.0/aiomcache/exceptions.py#L7

Whilst we could handle specifically in different backends, I think this is the best place to handle transparently and in future perhaps log cache miss etc. 

@long2ice could you please merge as a quick fix and do a new release? 

N.B. The PickleCoder fix on ```main``` also wasn't included in the v0.2.0 release so it's currently broken in PyPI, so need a new release anyway (this is why that's added in the changelog too)