### PR TITLE
add check if encode -> decode value is the same as the original value

### DIFF
--- a/fastapi_cache/coder.py
+++ b/fastapi_cache/coder.py
@@ -55,6 +55,8 @@ class JsonCoder(Coder):
     def encode(cls, value: Any) -> str:
         if isinstance(value, JSONResponse):
             return value.body
+        if cls.decode(json.dumps(value, cls=JsonEncoder)) != value:
+            raise ValueError("The value sent is not Json")
         return json.dumps(value, cls=JsonEncoder)
 
     @classmethod
@@ -70,5 +72,7 @@ class PickleCoder(Coder):
         return codecs.encode(pickle.dumps(value), "base64").decode()
 
     @classmethod
-    def decode(cls, value: str) -> Any:
-        return pickle.loads(codecs.decode(value.encode(), "base64"))  # nosec:B403,B301
+    def decode(cls, value: str | bytes) -> Any:
+        if isinstance(value, str):
+            value = value.encode()
+        return pickle.loads(codecs.decode(value, "base64"))  # nosec:B403,B301


### PR DESCRIPTION
https://github.com/long2ice/fastapi-cache/issues/120

This is a correction to the issue reported here.
In JsonCoder, if the encoded and decoded value does not match the original value, a ValueError is returned.

Also, together with this PR, I was able to fix the PickleCoder error.
Using redis, if decode_responses is false, the value of decode will be bytes.
JsonCoder works fine whether it comes in bytes or str, but PickleCoder gives an error if it is bytes.
Therefore, we fixed it.

``` python
    redis = aioredis.from_url(
        "redis://localhost",
        encoding="utf8",
        decode_responses=False, # False by default.
    )
    FastAPICache.init(RedisBackend(redis))
```