### PR TITLE
Attach updated endpoint signature to inner

### DIFF
--- a/examples/in_memory/main.py
+++ b/examples/in_memory/main.py
@@ -67,6 +67,19 @@ async def cache_response_obj():
     return JSONResponse({"a": 1})
 
 
+class SomeClass:
+    def __init__(self, value):
+        self.value = value
+
+    async def handler_method(self):
+        return self.value
+
+
+# register an instance method as a handler
+instance = SomeClass(17)
+app.get("/method")(cache(namespace="test")(instance.handler_method))
+
+
 @app.on_event("startup")
 async def startup():
     FastAPICache.init(InMemoryBackend())

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -73,3 +73,9 @@ def test_kwargs() -> None:
         name = "Jon"
         response = client.get("/kwargs", params={"name": name})
         assert response.json() == {"name": name}
+
+
+def test_method() -> None:
+    with TestClient(app) as client:
+        response = client.get("/method")
+        assert response.json() == 17


### PR DESCRIPTION
Not all endpoints accept a `__signature__` attribute, nor should the cache decorator modify the decorated endpoint. Attach the signature to the returned inner function instead.

While here, refactor the signature updating code, and extract it to a separate function.

Fixes #115
