### PR TITLE
Inject dependencies using a namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,21 @@ expire | int, states a caching time in seconds
 namespace | str, namespace to use to store certain cache items
 coder | which coder to use, e.g. JsonCoder
 key_builder | which key builder to use, default to builtin
+injected_dependency_namespace | prefix for injected dependency keywords, defaults to `__fastapi_cache`.
 
 You can also use `cache` as decorator like other cache tools to cache common function result.
+
+### Injected Request and Response dependencies
+
+The `cache` decorator adds dependencies for the `Request` and `Response` objects, so that it can
+add cache control headers to the outgoing response, and return a 304 Not Modified response when
+the incoming request has a matching If-Non-Match header. This only happens if the decorated
+endpoint doesn't already list these objects directly.
+
+The keyword arguments for these extra dependencies are named
+`__fastapi_cache_request` and `__fastapi_cache_response` to minimize collisions.
+Use the `injected_dependency_namespace` argument to `@cache()` to change the
+prefix used if those names would clash anyway.
 
 
 ### Supported data types

--- a/examples/in_memory/main.py
+++ b/examples/in_memory/main.py
@@ -106,6 +106,17 @@ async def uncached_put():
     return {"value": put_ret}
 
 
+@app.get("/namespaced_injection")
+@cache(namespace="test", expire=5, injected_dependency_namespace="monty_python")
+def namespaced_injection(
+    __fastapi_cache_request: int = 42, __fastapi_cache_response: int = 17
+) -> dict[str, int]:
+    return {
+        "__fastapi_cache_request": __fastapi_cache_request,
+        "__fastapi_cache_response": __fastapi_cache_response,
+    }
+
+
 @app.on_event("startup")
 async def startup():
     FastAPICache.init(InMemoryBackend())

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -94,3 +94,9 @@ def test_non_get() -> None:
         assert response.json() == {"value": 1}
         response = client.put("/uncached_put")
         assert response.json() == {"value": 2}
+
+
+def test_alternate_injected_namespace() -> None:
+    with TestClient(app) as client:
+        response = client.get("/namespaced_injection")
+        assert response.json() == {"__fastapi_cache_request": 42, "__fastapi_cache_response": 17}


### PR DESCRIPTION
Instead of assuming that the Request and Response injected keyword
arguments can be named `request` and `response`, use namespaced
keyword names starting with a double underscore.

By default the parameter names now start with `__fastapi_cache_` and so
are a) clearly marked as internal, and b) highly unlikely to clash with
existing keyword arguments. The prefix is configurable in the unlikely
event that the names would clash in specific cases.
