### PR TITLE
CI: don't run this workflow twice on a PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,12 @@
 name: ci
-on: [ push, pull_request ]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
 jobs:
   ci:
     strategy:


### PR DESCRIPTION
If a maintainer pushes to a PR, the workflow push and pull_request events
both trigger. Limit the workflow to the main branch, explicitly.
