### PR TITLE
Add pyupgrade linter

### DIFF
--- a/fastapi_cache/coder.py
+++ b/fastapi_cache/coder.py
@@ -52,7 +52,7 @@ def object_hook(obj: Any) -> Any:
     if _spec_type in CONVERTERS:
         return CONVERTERS[_spec_type](obj["val"])
     else:
-        raise TypeError("Unknown {}".format(_spec_type))
+        raise TypeError(f"Unknown {_spec_type}")
 
 
 class Coder:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ select = [
     "F", # pyflakes
     "I", # isort
     "W", # pycodestyle warnings
+    "UP", # pyupgrade
 ]
 target-version = "py37"
 


### PR DESCRIPTION
This ensures we use the best syntax for the minimal Python version used.  The linter found one issue, fixed with the auto-fixer.
