### PR TITLE
Add flake8-bandit linting

### DIFF
--- a/fastapi_cache/__init__.py
+++ b/fastapi_cache/__init__.py
@@ -59,12 +59,12 @@ class FastAPICache:
 
     @classmethod
     def get_backend(cls) -> Backend:
-        assert cls._backend, "You must call init first!"  # nosec: B101
+        assert cls._backend, "You must call init first!"  # noqa: S101
         return cls._backend
 
     @classmethod
     def get_prefix(cls) -> str:
-        assert cls._prefix is not None, "You must call init first!"  # nosec: B101
+        assert cls._prefix is not None, "You must call init first!"  # noqa: S101
         return cls._prefix
 
     @classmethod
@@ -73,17 +73,17 @@ class FastAPICache:
 
     @classmethod
     def get_coder(cls) -> Type[Coder]:
-        assert cls._coder, "You must call init first!"  # nosec: B101
+        assert cls._coder, "You must call init first!"  # noqa: S101
         return cls._coder
 
     @classmethod
     def get_key_builder(cls) -> KeyBuilder:
-        assert cls._key_builder, "You must call init first!"  # nosec: B101
+        assert cls._key_builder, "You must call init first!"  # noqa: S101
         return cls._key_builder
 
     @classmethod
     def get_cache_status_header(cls) -> str:
-        assert cls._cache_status_header, "You must call init first!"  # nosec: B101
+        assert cls._cache_status_header, "You must call init first!"  # noqa: S101
         return cls._cache_status_header
 
     @classmethod
@@ -92,6 +92,6 @@ class FastAPICache:
 
     @classmethod
     async def clear(cls, namespace: Optional[str] = None, key: Optional[str] = None) -> int:
-        assert cls._backend and cls._prefix is not None, "You must call init first!"  # nosec: B101
+        assert cls._backend and cls._prefix is not None, "You must call init first!"  # noqa: S101
         namespace = cls._prefix + (":" + namespace if namespace else "")
         return await cls._backend.clear(namespace, key)

--- a/fastapi_cache/coder.py
+++ b/fastapi_cache/coder.py
@@ -128,7 +128,7 @@ class PickleCoder(Coder):
 
     @classmethod
     def decode(cls, value: bytes) -> Any:
-        return pickle.loads(value)  # nosec:B403,B301
+        return pickle.loads(value)  # noqa: S301
 
     @classmethod
     def decode_as_type(cls, value: bytes, *, type_: Optional[_T]) -> Any:

--- a/fastapi_cache/decorator.py
+++ b/fastapi_cache/decorator.py
@@ -171,7 +171,7 @@ def cache(
             )
             if isawaitable(cache_key):
                 cache_key = await cache_key
-            assert isinstance(cache_key, str)
+            assert isinstance(cache_key, str)  # noqa: S101  # assertion is a type guard
 
             try:
                 ttl, cached = await backend.get_with_ttl(cache_key)

--- a/fastapi_cache/key_builder.py
+++ b/fastapi_cache/key_builder.py
@@ -14,7 +14,7 @@ def default_key_builder(
     args: Tuple[Any, ...],
     kwargs: Dict[str, Any],
 ) -> str:
-    cache_key = hashlib.md5(  # nosec:B303
+    cache_key = hashlib.md5(  # noqa: S324
         f"{func.__module__}:{func.__name__}:{args}:{kwargs}".encode()
     ).hexdigest()
     return f"{namespace}:{cache_key}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,10 +85,14 @@ select = [
     "E", # pycodestyle errors
     "F", # pyflakes
     "I", # isort
+    "S", # flake8-bandit
     "W", # pycodestyle warnings
     "UP", # pyupgrade
 ]
 target-version = "py37"
+
+[tool.ruff.per-file-ignores]
+"tests/**/*.py" = ["S101"]
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
The linter has been used in the past, so most assertions for these were already there but needed to be updated to use `noqa: S` instead of `nosec: B` annotations.
