### PR TITLE
Give tests and examples separate ruff configs

### DIFF
--- a/examples/in_memory/main.py
+++ b/examples/in_memory/main.py
@@ -4,13 +4,12 @@ from typing import Dict, Optional
 import pendulum
 import uvicorn
 from fastapi import FastAPI
-from pydantic import BaseModel
-from starlette.requests import Request
-from starlette.responses import JSONResponse, Response
-
 from fastapi_cache import FastAPICache
 from fastapi_cache.backends.inmemory import InMemoryBackend
 from fastapi_cache.decorator import cache
+from pydantic import BaseModel
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
 
 app = FastAPI()
 

--- a/examples/pyproject.toml
+++ b/examples/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.ruff]
+extend = "../pyproject.toml"
+

--- a/examples/redis/main.py
+++ b/examples/redis/main.py
@@ -2,20 +2,20 @@
 import time
 
 import pendulum
-import redis.asyncio as redis
 import uvicorn
 from fastapi import FastAPI
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
-from redis.asyncio.connection import ConnectionPool
-from starlette.requests import Request
-from starlette.responses import JSONResponse, Response
-
 from fastapi_cache import FastAPICache
 from fastapi_cache.backends.redis import RedisBackend
 from fastapi_cache.coder import PickleCoder
 from fastapi_cache.decorator import cache
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+import redis.asyncio as redis
+from redis.asyncio.connection import ConnectionPool
 
 app = FastAPI()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,9 +92,6 @@ select = [
 ]
 target-version = "py37"
 
-[tool.ruff.per-file-ignores]
-"tests/**/*.py" = ["S101"]
-
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.ruff]
+extend = "../pyproject.toml"
+ignore = ["S101"]
+
+[tool.ruff.isort]
+known-first-party = ["examples", "fastapi_cache"]
+


### PR DESCRIPTION
This allows more fine-grained lint rule adjustments, and allows
the examples to treat fastapi_cache as a 'third party' module, just
like users of the library would use it.
