### PR TITLE
Add pytest-style linting

### DIFF
--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -1,5 +1,8 @@
 [tool.ruff]
 extend = "../pyproject.toml"
+extend-select = [
+    "PT", # flake8-pytest-style
+]
 ignore = ["S101"]
 
 [tool.ruff.isort]

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -11,7 +11,7 @@ from fastapi_cache.backends.inmemory import InMemoryBackend
 
 
 @pytest.fixture(autouse=True)
-def init_cache() -> Generator[Any, Any, None]:
+def _init_cache() -> Generator[Any, Any, None]:  # pyright: ignore[reportUnusedFunction]
     FastAPICache.init(InMemoryBackend())
     yield
     FastAPICache.reset()


### PR DESCRIPTION
This does mean we need to tell pyright that the init_cache auto-use
fixture is still being used even though it now has a leading underscore.
