### PR TITLE
Configure dependabot and associated workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+- package-ecosystem: pip
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  target-branch: main
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  target-branch: main

--- a/dependabot-auto-merge.yml
+++ b/dependabot-auto-merge.yml
@@ -1,0 +1,35 @@
+name: Dependabot auto-merge
+on: pull_request_target
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@v1.4.0
+
+      - uses: actions/checkout@v3
+      - name: Approve PR
+        # only auto-approve direct deps that are minor or patch updates
+        #   dependency type is indirect, direct:development or direct:production
+        #   version-update is semver-major, semver-minor or semver-patch
+        if: |
+          steps.metadata.outputs.dependency-type != 'indirect'
+          && steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: |
+          if [ "$(gh pr view "$PR_URL" --json reviewDecision -q .reviewDecision)" != "APPROVED" ]; then
+            gh pr review --approve "$PR_URL"
+          else
+            echo "PR already approved, skipping additional approvals to minimize emails/notification noise."
+          fi
+          gh pr merge --auto --squash "$PR_URL"
+          gh pr edit "$PR_URL" --add-label "auto-merge"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/labeller.yaml
+++ b/labeller.yaml
@@ -1,0 +1,30 @@
+name: Labeller
+on:
+  pull_request_target:
+    types:
+      - auto_merge_disabled
+      - auto_merge_enabled
+  
+permissions: {}
+
+jobs:
+  add_remove_labels:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Add auto-merge label
+        if: github.event.action == 'auto_merge_enabled'
+        run: gh pr edit "$PR_URL" --add-label "auto-merge"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Remove auto-merge label
+        if: github.event.action == 'auto_merge_disabled'
+        run: gh pr edit "$PR_URL" --remove-label "auto-merge"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
The auto-merge workflow automatically approves dependabot PRs that
update dependencies or github actions where the semver difference is
at most a minor upgrade. These PRs are then auto-merged once the CI
checks have passed.

The labeller workflow adds / removes the auto-merge label to make
auto-merging more visible in issue lists and to make it possible to
filter such PRs. This workflow is unfortunately not triggered
when the auto-approve workflow enables auto-merging due to GH anti-
recursion rules, so the auto-merge workflow adds the label explicitly.
