### PR TITLE
#185 Allow for caching of non-GET requests

### DIFF
--- a/fastapi_cache/decorator.py
+++ b/fastapi_cache/decorator.py
@@ -79,8 +79,6 @@ def _uncacheable(request: Optional[Request]) -> bool:
         return True
     if request is None:
         return False
-    if request.method != "GET":
-        return True
     return request.headers.get("Cache-Control") in ("no-store", "no-cache")
 
 


### PR DESCRIPTION
I believe there's a use-case for allowing some non-GET requests to be cacheable.

Given restrictions on the length of HTTP requests, it is sometimes necessary to embed data into requests. Elasticsearch is an example that makes extensive use of GET requests using data, but this pattern is not possible with FastAPI because OpenAPI/Swagger does not support GET requests with embedded data.

As a result, if you want to use a FastAPI and have an endpoint that can accept large payloads (for example, because you want some sort of proxy in front of Elasticsearch, or a similar service) it is necessary to use a non-GET method, e.g. POST. However, fastapi-cache does not cache such queries.

This PR removes the restriction on non-GET requests so that it is up to the user of FastAPI to determine whether a method should be cached.