### PR TITLE
fix: fastapi dependencies import error

### DIFF
--- a/fastapi_cache/decorator.py
+++ b/fastapi_cache/decorator.py
@@ -19,10 +19,7 @@ else:
     from typing_extensions import ParamSpec
 
 from fastapi.concurrency import run_in_threadpool
-from fastapi.dependencies.utils import (
-    get_typed_return_annotation,
-    get_typed_signature,
-)
+from fastapi.dependencies.utils import get_typed_signature
 from starlette.requests import Request
 from starlette.responses import Response
 from starlette.status import HTTP_304_NOT_MODIFIED
@@ -30,6 +27,7 @@ from starlette.status import HTTP_304_NOT_MODIFIED
 from fastapi_cache import FastAPICache
 from fastapi_cache.coder import Coder
 from fastapi_cache.types import KeyBuilder
+from fastapi_cache.utils import get_typed_return_annotation
 
 logger: logging.Logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())

--- a/fastapi_cache/utils.py
+++ b/fastapi_cache/utils.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import Any, Dict, ForwardRef, Callable
+from typing import Any, Callable, Dict, ForwardRef
 
 from pydantic.typing import evaluate_forwardref
 

--- a/fastapi_cache/utils.py
+++ b/fastapi_cache/utils.py
@@ -1,0 +1,22 @@
+import inspect
+from typing import Any, Dict, ForwardRef, Callable
+
+from pydantic.typing import evaluate_forwardref
+
+
+def get_typed_annotation(annotation: Any, globalns: Dict[str, Any]) -> Any:
+    if isinstance(annotation, str):
+        annotation = ForwardRef(annotation)
+        annotation = evaluate_forwardref(annotation, globalns, globalns)
+    return annotation
+
+
+def get_typed_return_annotation(call: Callable[..., Any]) -> Any:
+    signature = inspect.signature(call)
+    annotation = signature.return_annotation
+
+    if annotation is inspect.Signature.empty:
+        return None
+
+    globalns = getattr(call, "__globals__", {})
+    return get_typed_annotation(annotation, globalns)


### PR DESCRIPTION
The `get_typed_return_annotation` method is only available after fastapi 0.89.0.

This PR is compatible with previous versions.