### PR TITLE
🐛 Update decorator.py to respect coder encoding for args and kwargs

### DIFF
--- a/fastapi_cache/decorator.py
+++ b/fastapi_cache/decorator.py
@@ -166,8 +166,8 @@ def cache(
                 f"{prefix}:{namespace}",
                 request=request,
                 response=response,
-                args=args,
-                kwargs=copy_kwargs,
+                args=coder.encode(args),
+                kwargs=coder.encode(copy_kwargs),
             )
             if isawaitable(cache_key):
                 cache_key = await cache_key


### PR DESCRIPTION
I'm recreating this PR since the [previously one](https://github.com/long2ice/fastapi-cache/pull/9) was (accidentally?) closed. If this is not a desired change, it would be great to explain the proper way to deal with non-standard arg objects.