### PR TITLE
bugfix: type hint @cache for non-awaitable functions

### DIFF
--- a/fastapi_cache/decorator.py
+++ b/fastapi_cache/decorator.py
@@ -91,7 +91,7 @@ def cache(
     namespace: str = "",
     injected_dependency_namespace: str = "__fastapi_cache",
 ) -> Callable[
-    [Callable[P, Union[R,Awaitable[R]]]],
+    [Callable[P, Union[R, Awaitable[R]]]],
     Callable[P, Awaitable[Union[R, Response]]]
 ]:
     """

--- a/fastapi_cache/decorator.py
+++ b/fastapi_cache/decorator.py
@@ -90,7 +90,10 @@ def cache(
     key_builder: Optional[KeyBuilder] = None,
     namespace: str = "",
     injected_dependency_namespace: str = "__fastapi_cache",
-) -> Callable[[Callable[P, Awaitable[R]]], Callable[P, Awaitable[Union[R, Response]]]]:
+) -> Callable[
+    [Callable[P, Union[R,Awaitable[R]]]],
+    Callable[P, Awaitable[Union[R, Response]]]
+]:
     """
     cache all function
     :param namespace:
@@ -113,7 +116,7 @@ def cache(
     )
 
     def wrapper(
-        func: Callable[P, Awaitable[R]]
+        func: Callable[P, Union[R, Awaitable[R]]]
     ) -> Callable[P, Awaitable[Union[R, Response]]]:
         # get_typed_signature ensures that any forward references are resolved first
         wrapped_signature = get_typed_signature(func)


### PR DESCRIPTION
@cache's type hint allowed only awaitables, although the implementation supported both.
This commit allows both awaitables and non-awaitables for @cache's type hint.