### PR TITLE
Add usedforsecurity flag into key builder md5 usage

### DIFF
--- a/fastapi_cache/key_builder.py
+++ b/fastapi_cache/key_builder.py
@@ -15,6 +15,7 @@ def default_key_builder(
     kwargs: Dict[str, Any],
 ) -> str:
     cache_key = hashlib.md5(  # noqa: S324
-        f"{func.__module__}:{func.__name__}:{args}:{kwargs}".encode()
+        f"{func.__module__}:{func.__name__}:{args}:{kwargs}".encode(),
+        usedforsecurity=False,
     ).hexdigest()
     return f"{namespace}:{cache_key}"


### PR DESCRIPTION
This flag indicated that md5 hash function usage is not used for security purposes.
It is a good practice to add it so that security linters do not fail on it.