### PR TITLE
fix(docs): update function signature of `request_key_builder`

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,13 +181,13 @@ For example, if you wanted to use the request method, URL and query string as a 
 
 ```python
 def request_key_builder(
-    func,
+    func: Callable[..., Any],
     namespace: str = "",
     *,
-    request: Request = None,
-    response: Response = None,
-    *args,
-    **kwargs,
+    request: Optional[Request] = None,
+    response: Optional[Response] = None,
+    args: Tuple[Any, ...],
+    kwargs: Dict[str, Any],
 ):
     return ":".join([
         namespace,


### PR DESCRIPTION
<img width="509" alt="스크린샷 2023-12-18 오후 4 17 54" src="https://github.com/long2ice/fastapi-cache/assets/8033896/823ea736-6e6c-4fa7-bbbf-2498f6e8205d">

I believe the function signature of `request_key_builder` in the example is outdated.

This PR updates the example to synchronize with the signature of default_key_builder available at: https://github.com/long2ice/fastapi-cache/blob/91ba6d75524b1f6a17ae6a3300ab51b9aa1fcf71/fastapi_cache/key_builder.py#L8