### PR TITLE
Switch from on_event to lifespan asynccontextmanager #422

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ or
 ### Quick Start
 
 ```python
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
 from starlette.requests import Request
 from starlette.responses import Response
@@ -74,12 +77,11 @@ async def get_cache():
 async def index():
     return dict(hello="world")
 
-
-@app.on_event("startup")
-async def startup():
+@asynccontextmanager
+async def lifespan(_: FastAPI) -> AsyncIterator[None]:
     redis = aioredis.from_url("redis://localhost")
     FastAPICache.init(RedisBackend(redis), prefix="fastapi-cache")
-
+    yield
 ```
 
 ### Initialization


### PR DESCRIPTION
on_event is now deprecated, and to be replaced with lifespan: https://fastapi.tiangolo.com/advanced/events/
Solves https://github.com/long2ice/fastapi-cache/issues/422