### PR TITLE
[FIX] FastAPICache.init bug, by updating README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,14 @@ from fastapi_cache.decorator import cache
 
 from redis import asyncio as aioredis
 
-app = FastAPI()
+@asynccontextmanager
+async def lifespan(_: FastAPI) -> AsyncIterator[None]:
+    redis = aioredis.from_url("redis://localhost")
+    FastAPICache.init(RedisBackend(redis), prefix="fastapi-cache")
+    yield
+
+
+app = FastAPI(lifespan=lifespan)
 
 
 @cache()
@@ -77,11 +84,6 @@ async def get_cache():
 async def index():
     return dict(hello="world")
 
-@asynccontextmanager
-async def lifespan(_: FastAPI) -> AsyncIterator[None]:
-    redis = aioredis.from_url("redis://localhost")
-    FastAPICache.init(RedisBackend(redis), prefix="fastapi-cache")
-    yield
 ```
 
 ### Initialization


### PR DESCRIPTION
[FIX] "You must call init first!" bug, as the `lifespan` was not bound to the `app` instance