### PR TITLE
Fix header for caching binary responses.

### DIFF
--- a/fastapi_cache/decorator.py
+++ b/fastapi_cache/decorator.py
@@ -221,7 +221,8 @@ def cache(
                         return response
 
                 result = cast(R, coder.decode_as_type(cached, type_=return_type))
-
+                if isinstance(result, Response):
+                    result.headers.update(response.headers)
             return result
 
         inner.__signature__ = _augment_signature(wrapped_signature, *to_inject)  # type: ignore[attr-defined]


### PR DESCRIPTION
Based on [hozn](https://github.com/hozn) in [#283](https://github.com/long2ice/fastapi-cache/issues/283), this is a simple modification that allow to copy headers if a custom encoder return an instance of a starlette response. 

So we can cache binary data with custom response and have all the fastapi-cache header set.
