### PR TITLE
Backends clear method expects keys to start with prefix

### DIFF
--- a/fastapi_cache/decorator.py
+++ b/fastapi_cache/decorator.py
@@ -164,7 +164,7 @@ def cache(
 
             cache_key = key_builder(
                 func,
-                f"{prefix}:{namespace}",
+                f"{namespace}:{prefix}",
                 request=request,
                 response=response,
                 args=args,


### PR DESCRIPTION
Values cached by the `cache` decorator wouldn't be cleared if the `Backend.clear` method is called without arguments. Because the backends that implement `clear` expect the key to start with `namespace`.

https://github.com/long2ice/fastapi-cache/blob/157a91359b42ecbd0dd4498db12797dac8050af7/fastapi_cache/backends/redis.py#L26

https://github.com/long2ice/fastapi-cache/blob/157a91359b42ecbd0dd4498db12797dac8050af7/fastapi_cache/backends/inmemory.py#L55