### PR TITLE
Add Valkey backend support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 ## Introduction
 
 `fastapi-cache` is a tool to cache FastAPI endpoint and function results, with
-backends supporting Redis, Memcached, and Amazon DynamoDB.
+backends supporting Redis, Valkey, Memcached, and Amazon DynamoDB.
 
 ## Features
 
-- Supports `redis`, `memcache`, `dynamodb`, and `in-memory` backends.
+- Supports `redis`, `valkey`, `memcache`, `dynamodb`, and `in-memory` backends.
 - Easy integration with [FastAPI](https://fastapi.tiangolo.com/).
 - Support for HTTP cache headers like `ETag` and `Cache-Control`, as well as conditional `If-Match-None` requests.
 
@@ -19,6 +19,7 @@ backends supporting Redis, Memcached, and Amazon DynamoDB.
 
 - FastAPI
 - `redis` when using `RedisBackend`.
+- `valkey` when using `ValkeyBackend`.
 - `memcache` when using `MemcacheBackend`.
 - `aiobotocore` when using `DynamoBackend`.
 
@@ -220,6 +221,12 @@ data has been cached, the data will not be removed automatically.
 When using the Redis backend, please make sure you pass in a redis client that does [_not_ decode responses][redis-decode] (`decode_responses` **must** be `False`, which is the default). Cached data is stored as `bytes` (binary), decoding these in the Redis client would break caching.
 
 [redis-decode]: https://redis-py.readthedocs.io/en/latest/examples/connection_examples.html#by-default-Redis-return-binary-responses,-to-decode-them-use-decode_responses=True
+
+### ValkeyBackend
+
+As with the Redis backend, When using the Valkey backend, please make sure you pass in a valkey client that does [_not_ decode responses][valkey-decode] (`decode_responses` **must** be `False`, which is the default). Cached data is stored as `bytes` (binary), decoding these in the Redis client would break caching.
+
+[valkey-decode]: https://valkey-py.readthedocs.io/en/latest/examples/connection_examples.html#By-default-Valkey-return-binary-responses,-to-decode-them-use-decode_responses=True
 
 ## Tests and coverage
 

--- a/fastapi_cache/backends/valkey.py
+++ b/fastapi_cache/backends/valkey.py
@@ -1,0 +1,37 @@
+"""
+fastapi-cache - Valkey cache backend support
+"""
+from typing import Optional, Tuple, Union
+
+from valkey.asyncio.client import Valkey
+from valkey.asyncio.cluster import ValkeyCluster
+
+from fastapi_cache.types import Backend
+
+
+class ValkeyBackend(Backend):
+    """
+    Valkey cache backend
+    """
+
+    def __init__(self, valkey: Union[Valkey, ValkeyCluster]):
+        self.valkey = valkey
+        self.is_cluster: bool = isinstance(valkey, ValkeyCluster)
+
+    async def get_with_ttl(self, key: str) -> Tuple[int, Optional[bytes]]:
+        async with self.valkey.pipeline(transaction=not self.is_cluster) as pipe:
+            return await pipe.ttl(key).get(key).execute()   # type: ignore[union-attr,no-any-return]
+
+    async def get(self, key: str) -> Optional[bytes]:
+        return await self.valkey.get(key)   # type: ignore[no-any-return]
+
+    async def set(self, key: str, value: bytes, expire: Optional[int] = None) -> None:
+        await self.valkey.set(key, value, ex=expire)
+
+    async def clear(self, namespace: Optional[str] = None, key: Optional[str] = None) -> int:
+        if namespace:
+            lua = f"for i, name in ipairs(redis.call('KEYS', '{namespace}:*')) do redis.call('DEL', name); end"
+            return await self.valkey.eval(lua, numkeys=0)   # type: ignore[misc,no-any-return]
+        if key:
+            return await self.valkey.delete(key)    # type: ignore[no-any-return]
+        return 0

--- a/poetry.lock
+++ b/poetry.lock
@@ -2,134 +2,134 @@
 
 [[package]]
 name = "aiobotocore"
-version = "2.15.0"
+version = "2.15.1"
 description = "Async client for aws services using botocore and aiohttp"
 optional = true
 python-versions = ">=3.8"
 files = [
-    {file = "aiobotocore-2.15.0-py3-none-any.whl", hash = "sha256:6d0b4a51d70bc33b1b4eba411076b0cc979aecbdad8e084bab202202423c0725"},
-    {file = "aiobotocore-2.15.0.tar.gz", hash = "sha256:988eef33fd9dd4b070959cfec922278e84166950695b2160bd581623cb6a420c"},
+    {file = "aiobotocore-2.15.1-py3-none-any.whl", hash = "sha256:0f738cde74108553b753b24655094289a3c7ea0f0f179ed1c0f8cea488999a35"},
+    {file = "aiobotocore-2.15.1.tar.gz", hash = "sha256:1f9f16eec2a3da32df162b5db12da779ec6d6c6311715c936cad511f436efa74"},
 ]
 
 [package.dependencies]
 aiohttp = ">=3.9.2,<4.0.0"
 aioitertools = ">=0.5.1,<1.0.0"
-botocore = ">=1.35.16,<1.35.17"
+botocore = ">=1.35.16,<1.35.24"
 wrapt = ">=1.10.10,<2.0.0"
 
 [package.extras]
-awscli = ["awscli (>=1.34.16,<1.34.17)"]
-boto3 = ["boto3 (>=1.35.16,<1.35.17)"]
+awscli = ["awscli (>=1.34.16,<1.34.24)"]
+boto3 = ["boto3 (>=1.35.16,<1.35.24)"]
 
 [[package]]
 name = "aiohappyeyeballs"
-version = "2.4.0"
+version = "2.4.3"
 description = "Happy Eyeballs for asyncio"
 optional = true
 python-versions = ">=3.8"
 files = [
-    {file = "aiohappyeyeballs-2.4.0-py3-none-any.whl", hash = "sha256:7ce92076e249169a13c2f49320d1967425eaf1f407522d707d59cac7628d62bd"},
-    {file = "aiohappyeyeballs-2.4.0.tar.gz", hash = "sha256:55a1714f084e63d49639800f95716da97a1f173d46a16dfcfda0016abb93b6b2"},
+    {file = "aiohappyeyeballs-2.4.3-py3-none-any.whl", hash = "sha256:8a7a83727b2756f394ab2895ea0765a0a8c475e3c71e98d43d76f22b4b435572"},
+    {file = "aiohappyeyeballs-2.4.3.tar.gz", hash = "sha256:75cf88a15106a5002a8eb1dab212525c00d1f4c0fa96e551c9fbe6f09a621586"},
 ]
 
 [[package]]
 name = "aiohttp"
-version = "3.10.5"
+version = "3.10.8"
 description = "Async http client/server framework (asyncio)"
 optional = true
 python-versions = ">=3.8"
 files = [
-    {file = "aiohttp-3.10.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:18a01eba2574fb9edd5f6e5fb25f66e6ce061da5dab5db75e13fe1558142e0a3"},
-    {file = "aiohttp-3.10.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:94fac7c6e77ccb1ca91e9eb4cb0ac0270b9fb9b289738654120ba8cebb1189c6"},
-    {file = "aiohttp-3.10.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2f1f1c75c395991ce9c94d3e4aa96e5c59c8356a15b1c9231e783865e2772699"},
-    {file = "aiohttp-3.10.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f7acae3cf1a2a2361ec4c8e787eaaa86a94171d2417aae53c0cca6ca3118ff6"},
-    {file = "aiohttp-3.10.5-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:94c4381ffba9cc508b37d2e536b418d5ea9cfdc2848b9a7fea6aebad4ec6aac1"},
-    {file = "aiohttp-3.10.5-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c31ad0c0c507894e3eaa843415841995bf8de4d6b2d24c6e33099f4bc9fc0d4f"},
-    {file = "aiohttp-3.10.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0912b8a8fadeb32ff67a3ed44249448c20148397c1ed905d5dac185b4ca547bb"},
-    {file = "aiohttp-3.10.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0d93400c18596b7dc4794d48a63fb361b01a0d8eb39f28800dc900c8fbdaca91"},
-    {file = "aiohttp-3.10.5-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d00f3c5e0d764a5c9aa5a62d99728c56d455310bcc288a79cab10157b3af426f"},
-    {file = "aiohttp-3.10.5-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:d742c36ed44f2798c8d3f4bc511f479b9ceef2b93f348671184139e7d708042c"},
-    {file = "aiohttp-3.10.5-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:814375093edae5f1cb31e3407997cf3eacefb9010f96df10d64829362ae2df69"},
-    {file = "aiohttp-3.10.5-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:8224f98be68a84b19f48e0bdc14224b5a71339aff3a27df69989fa47d01296f3"},
-    {file = "aiohttp-3.10.5-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:d9a487ef090aea982d748b1b0d74fe7c3950b109df967630a20584f9a99c0683"},
-    {file = "aiohttp-3.10.5-cp310-cp310-win32.whl", hash = "sha256:d9ef084e3dc690ad50137cc05831c52b6ca428096e6deb3c43e95827f531d5ef"},
-    {file = "aiohttp-3.10.5-cp310-cp310-win_amd64.whl", hash = "sha256:66bf9234e08fe561dccd62083bf67400bdbf1c67ba9efdc3dac03650e97c6088"},
-    {file = "aiohttp-3.10.5-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:8c6a4e5e40156d72a40241a25cc226051c0a8d816610097a8e8f517aeacd59a2"},
-    {file = "aiohttp-3.10.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2c634a3207a5445be65536d38c13791904fda0748b9eabf908d3fe86a52941cf"},
-    {file = "aiohttp-3.10.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4aff049b5e629ef9b3e9e617fa6e2dfeda1bf87e01bcfecaf3949af9e210105e"},
-    {file = "aiohttp-3.10.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1942244f00baaacaa8155eca94dbd9e8cc7017deb69b75ef67c78e89fdad3c77"},
-    {file = "aiohttp-3.10.5-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e04a1f2a65ad2f93aa20f9ff9f1b672bf912413e5547f60749fa2ef8a644e061"},
-    {file = "aiohttp-3.10.5-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7f2bfc0032a00405d4af2ba27f3c429e851d04fad1e5ceee4080a1c570476697"},
-    {file = "aiohttp-3.10.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:424ae21498790e12eb759040bbb504e5e280cab64693d14775c54269fd1d2bb7"},
-    {file = "aiohttp-3.10.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:975218eee0e6d24eb336d0328c768ebc5d617609affaca5dbbd6dd1984f16ed0"},
-    {file = "aiohttp-3.10.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4120d7fefa1e2d8fb6f650b11489710091788de554e2b6f8347c7a20ceb003f5"},
-    {file = "aiohttp-3.10.5-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:b90078989ef3fc45cf9221d3859acd1108af7560c52397ff4ace8ad7052a132e"},
-    {file = "aiohttp-3.10.5-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:ba5a8b74c2a8af7d862399cdedce1533642fa727def0b8c3e3e02fcb52dca1b1"},
-    {file = "aiohttp-3.10.5-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:02594361128f780eecc2a29939d9dfc870e17b45178a867bf61a11b2a4367277"},
-    {file = "aiohttp-3.10.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:8fb4fc029e135859f533025bc82047334e24b0d489e75513144f25408ecaf058"},
-    {file = "aiohttp-3.10.5-cp311-cp311-win32.whl", hash = "sha256:e1ca1ef5ba129718a8fc827b0867f6aa4e893c56eb00003b7367f8a733a9b072"},
-    {file = "aiohttp-3.10.5-cp311-cp311-win_amd64.whl", hash = "sha256:349ef8a73a7c5665cca65c88ab24abe75447e28aa3bc4c93ea5093474dfdf0ff"},
-    {file = "aiohttp-3.10.5-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:305be5ff2081fa1d283a76113b8df7a14c10d75602a38d9f012935df20731487"},
-    {file = "aiohttp-3.10.5-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:3a1c32a19ee6bbde02f1cb189e13a71b321256cc1d431196a9f824050b160d5a"},
-    {file = "aiohttp-3.10.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:61645818edd40cc6f455b851277a21bf420ce347baa0b86eaa41d51ef58ba23d"},
-    {file = "aiohttp-3.10.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6c225286f2b13bab5987425558baa5cbdb2bc925b2998038fa028245ef421e75"},
-    {file = "aiohttp-3.10.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8ba01ebc6175e1e6b7275c907a3a36be48a2d487549b656aa90c8a910d9f3178"},
-    {file = "aiohttp-3.10.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8eaf44ccbc4e35762683078b72bf293f476561d8b68ec8a64f98cf32811c323e"},
-    {file = "aiohttp-3.10.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b1c43eb1ab7cbf411b8e387dc169acb31f0ca0d8c09ba63f9eac67829585b44f"},
-    {file = "aiohttp-3.10.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:de7a5299827253023c55ea549444e058c0eb496931fa05d693b95140a947cb73"},
-    {file = "aiohttp-3.10.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4790f0e15f00058f7599dab2b206d3049d7ac464dc2e5eae0e93fa18aee9e7bf"},
-    {file = "aiohttp-3.10.5-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:44b324a6b8376a23e6ba25d368726ee3bc281e6ab306db80b5819999c737d820"},
-    {file = "aiohttp-3.10.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:0d277cfb304118079e7044aad0b76685d30ecb86f83a0711fc5fb257ffe832ca"},
-    {file = "aiohttp-3.10.5-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:54d9ddea424cd19d3ff6128601a4a4d23d54a421f9b4c0fff740505813739a91"},
-    {file = "aiohttp-3.10.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4f1c9866ccf48a6df2b06823e6ae80573529f2af3a0992ec4fe75b1a510df8a6"},
-    {file = "aiohttp-3.10.5-cp312-cp312-win32.whl", hash = "sha256:dc4826823121783dccc0871e3f405417ac116055bf184ac04c36f98b75aacd12"},
-    {file = "aiohttp-3.10.5-cp312-cp312-win_amd64.whl", hash = "sha256:22c0a23a3b3138a6bf76fc553789cb1a703836da86b0f306b6f0dc1617398abc"},
-    {file = "aiohttp-3.10.5-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:7f6b639c36734eaa80a6c152a238242bedcee9b953f23bb887e9102976343092"},
-    {file = "aiohttp-3.10.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f29930bc2921cef955ba39a3ff87d2c4398a0394ae217f41cb02d5c26c8b1b77"},
-    {file = "aiohttp-3.10.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f489a2c9e6455d87eabf907ac0b7d230a9786be43fbe884ad184ddf9e9c1e385"},
-    {file = "aiohttp-3.10.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:123dd5b16b75b2962d0fff566effb7a065e33cd4538c1692fb31c3bda2bfb972"},
-    {file = "aiohttp-3.10.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b98e698dc34966e5976e10bbca6d26d6724e6bdea853c7c10162a3235aba6e16"},
-    {file = "aiohttp-3.10.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c3b9162bab7e42f21243effc822652dc5bb5e8ff42a4eb62fe7782bcbcdfacf6"},
-    {file = "aiohttp-3.10.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1923a5c44061bffd5eebeef58cecf68096e35003907d8201a4d0d6f6e387ccaa"},
-    {file = "aiohttp-3.10.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d55f011da0a843c3d3df2c2cf4e537b8070a419f891c930245f05d329c4b0689"},
-    {file = "aiohttp-3.10.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:afe16a84498441d05e9189a15900640a2d2b5e76cf4efe8cbb088ab4f112ee57"},
-    {file = "aiohttp-3.10.5-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:f8112fb501b1e0567a1251a2fd0747baae60a4ab325a871e975b7bb67e59221f"},
-    {file = "aiohttp-3.10.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:1e72589da4c90337837fdfe2026ae1952c0f4a6e793adbbfbdd40efed7c63599"},
-    {file = "aiohttp-3.10.5-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:4d46c7b4173415d8e583045fbc4daa48b40e31b19ce595b8d92cf639396c15d5"},
-    {file = "aiohttp-3.10.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:33e6bc4bab477c772a541f76cd91e11ccb6d2efa2b8d7d7883591dfb523e5987"},
-    {file = "aiohttp-3.10.5-cp313-cp313-win32.whl", hash = "sha256:c58c6837a2c2a7cf3133983e64173aec11f9c2cd8e87ec2fdc16ce727bcf1a04"},
-    {file = "aiohttp-3.10.5-cp313-cp313-win_amd64.whl", hash = "sha256:38172a70005252b6893088c0f5e8a47d173df7cc2b2bd88650957eb84fcf5022"},
-    {file = "aiohttp-3.10.5-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:f6f18898ace4bcd2d41a122916475344a87f1dfdec626ecde9ee802a711bc569"},
-    {file = "aiohttp-3.10.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:5ede29d91a40ba22ac1b922ef510aab871652f6c88ef60b9dcdf773c6d32ad7a"},
-    {file = "aiohttp-3.10.5-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:673f988370f5954df96cc31fd99c7312a3af0a97f09e407399f61583f30da9bc"},
-    {file = "aiohttp-3.10.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:58718e181c56a3c02d25b09d4115eb02aafe1a732ce5714ab70326d9776457c3"},
-    {file = "aiohttp-3.10.5-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4b38b1570242fbab8d86a84128fb5b5234a2f70c2e32f3070143a6d94bc854cf"},
-    {file = "aiohttp-3.10.5-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:074d1bff0163e107e97bd48cad9f928fa5a3eb4b9d33366137ffce08a63e37fe"},
-    {file = "aiohttp-3.10.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd31f176429cecbc1ba499d4aba31aaccfea488f418d60376b911269d3b883c5"},
-    {file = "aiohttp-3.10.5-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7384d0b87d4635ec38db9263e6a3f1eb609e2e06087f0aa7f63b76833737b471"},
-    {file = "aiohttp-3.10.5-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:8989f46f3d7ef79585e98fa991e6ded55d2f48ae56d2c9fa5e491a6e4effb589"},
-    {file = "aiohttp-3.10.5-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:c83f7a107abb89a227d6c454c613e7606c12a42b9a4ca9c5d7dad25d47c776ae"},
-    {file = "aiohttp-3.10.5-cp38-cp38-musllinux_1_2_ppc64le.whl", hash = "sha256:cde98f323d6bf161041e7627a5fd763f9fd829bcfcd089804a5fdce7bb6e1b7d"},
-    {file = "aiohttp-3.10.5-cp38-cp38-musllinux_1_2_s390x.whl", hash = "sha256:676f94c5480d8eefd97c0c7e3953315e4d8c2b71f3b49539beb2aa676c58272f"},
-    {file = "aiohttp-3.10.5-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:2d21ac12dc943c68135ff858c3a989f2194a709e6e10b4c8977d7fcd67dfd511"},
-    {file = "aiohttp-3.10.5-cp38-cp38-win32.whl", hash = "sha256:17e997105bd1a260850272bfb50e2a328e029c941c2708170d9d978d5a30ad9a"},
-    {file = "aiohttp-3.10.5-cp38-cp38-win_amd64.whl", hash = "sha256:1c19de68896747a2aa6257ae4cf6ef59d73917a36a35ee9d0a6f48cff0f94db8"},
-    {file = "aiohttp-3.10.5-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:7e2fe37ac654032db1f3499fe56e77190282534810e2a8e833141a021faaab0e"},
-    {file = "aiohttp-3.10.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f5bf3ead3cb66ab990ee2561373b009db5bc0e857549b6c9ba84b20bc462e172"},
-    {file = "aiohttp-3.10.5-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:1b2c16a919d936ca87a3c5f0e43af12a89a3ce7ccbce59a2d6784caba945b68b"},
-    {file = "aiohttp-3.10.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad146dae5977c4dd435eb31373b3fe9b0b1bf26858c6fc452bf6af394067e10b"},
-    {file = "aiohttp-3.10.5-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8c5c6fa16412b35999320f5c9690c0f554392dc222c04e559217e0f9ae244b92"},
-    {file = "aiohttp-3.10.5-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:95c4dc6f61d610bc0ee1edc6f29d993f10febfe5b76bb470b486d90bbece6b22"},
-    {file = "aiohttp-3.10.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:da452c2c322e9ce0cfef392e469a26d63d42860f829026a63374fde6b5c5876f"},
-    {file = "aiohttp-3.10.5-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:898715cf566ec2869d5cb4d5fb4be408964704c46c96b4be267442d265390f32"},
-    {file = "aiohttp-3.10.5-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:391cc3a9c1527e424c6865e087897e766a917f15dddb360174a70467572ac6ce"},
-    {file = "aiohttp-3.10.5-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:380f926b51b92d02a34119d072f178d80bbda334d1a7e10fa22d467a66e494db"},
-    {file = "aiohttp-3.10.5-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:ce91db90dbf37bb6fa0997f26574107e1b9d5ff939315247b7e615baa8ec313b"},
-    {file = "aiohttp-3.10.5-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:9093a81e18c45227eebe4c16124ebf3e0d893830c6aca7cc310bfca8fe59d857"},
-    {file = "aiohttp-3.10.5-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:ee40b40aa753d844162dcc80d0fe256b87cba48ca0054f64e68000453caead11"},
-    {file = "aiohttp-3.10.5-cp39-cp39-win32.whl", hash = "sha256:03f2645adbe17f274444953bdea69f8327e9d278d961d85657cb0d06864814c1"},
-    {file = "aiohttp-3.10.5-cp39-cp39-win_amd64.whl", hash = "sha256:d17920f18e6ee090bdd3d0bfffd769d9f2cb4c8ffde3eb203777a3895c128862"},
-    {file = "aiohttp-3.10.5.tar.gz", hash = "sha256:f071854b47d39591ce9a17981c46790acb30518e2f83dfca8db2dfa091178691"},
+    {file = "aiohttp-3.10.8-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a1ba7bc139592339ddeb62c06486d0fa0f4ca61216e14137a40d626c81faf10c"},
+    {file = "aiohttp-3.10.8-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:85e4d7bd05d18e4b348441e7584c681eff646e3bf38f68b2626807f3add21aa2"},
+    {file = "aiohttp-3.10.8-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:69de056022e7abf69cb9fec795515973cc3eeaff51e3ea8d72a77aa933a91c52"},
+    {file = "aiohttp-3.10.8-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ee3587506898d4a404b33bd19689286ccf226c3d44d7a73670c8498cd688e42c"},
+    {file = "aiohttp-3.10.8-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fe285a697c851734285369614443451462ce78aac2b77db23567507484b1dc6f"},
+    {file = "aiohttp-3.10.8-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:10c7932337285a6bfa3a5fe1fd4da90b66ebfd9d0cbd1544402e1202eb9a8c3e"},
+    {file = "aiohttp-3.10.8-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cd9716ef0224fe0d0336997eb242f40619f9f8c5c57e66b525a1ebf9f1d8cebe"},
+    {file = "aiohttp-3.10.8-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ceacea31f8a55cdba02bc72c93eb2e1b77160e91f8abd605969c168502fd71eb"},
+    {file = "aiohttp-3.10.8-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:9721554bfa9e15f6e462da304374c2f1baede3cb06008c36c47fa37ea32f1dc4"},
+    {file = "aiohttp-3.10.8-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:22cdeb684d8552490dd2697a5138c4ecb46f844892df437aaf94f7eea99af879"},
+    {file = "aiohttp-3.10.8-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:e56bb7e31c4bc79956b866163170bc89fd619e0581ce813330d4ea46921a4881"},
+    {file = "aiohttp-3.10.8-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:3a95d2686bc4794d66bd8de654e41b5339fab542b2bca9238aa63ed5f4f2ce82"},
+    {file = "aiohttp-3.10.8-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:d82404a0e7b10e0d7f022cf44031b78af8a4f99bd01561ac68f7c24772fed021"},
+    {file = "aiohttp-3.10.8-cp310-cp310-win32.whl", hash = "sha256:4e10b04542d27e21538e670156e88766543692a0a883f243ba8fad9ddea82e53"},
+    {file = "aiohttp-3.10.8-cp310-cp310-win_amd64.whl", hash = "sha256:680dbcff5adc7f696ccf8bf671d38366a1f620b5616a1d333d0cb33956065395"},
+    {file = "aiohttp-3.10.8-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:33a68011a38020ed4ff41ae0dbf4a96a202562ecf2024bdd8f65385f1d07f6ef"},
+    {file = "aiohttp-3.10.8-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6c7efa6616a95e3bd73b8a69691012d2ef1f95f9ea0189e42f338fae080c2fc6"},
+    {file = "aiohttp-3.10.8-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ddb9b9764cfb4459acf01c02d2a59d3e5066b06a846a364fd1749aa168efa2be"},
+    {file = "aiohttp-3.10.8-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3c7f270f4ca92760f98a42c45a58674fff488e23b144ec80b1cc6fa2effed377"},
+    {file = "aiohttp-3.10.8-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6984dda9d79064361ab58d03f6c1e793ea845c6cfa89ffe1a7b9bb400dfd56bd"},
+    {file = "aiohttp-3.10.8-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3f6d47e392c27206701565c8df4cac6ebed28fdf6dcaea5b1eea7a4631d8e6db"},
+    {file = "aiohttp-3.10.8-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a72f89aea712c619b2ca32c6f4335c77125ede27530ad9705f4f349357833695"},
+    {file = "aiohttp-3.10.8-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c36074b26f3263879ba8e4dbd33db2b79874a3392f403a70b772701363148b9f"},
+    {file = "aiohttp-3.10.8-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e32148b4a745e70a255a1d44b5664de1f2e24fcefb98a75b60c83b9e260ddb5b"},
+    {file = "aiohttp-3.10.8-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:5aa1a073514cf59c81ad49a4ed9b5d72b2433638cd53160fd2f3a9cfa94718db"},
+    {file = "aiohttp-3.10.8-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:d3a79200a9d5e621c4623081ddb25380b713c8cf5233cd11c1aabad990bb9381"},
+    {file = "aiohttp-3.10.8-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:e45fdfcb2d5bcad83373e4808825b7512953146d147488114575780640665027"},
+    {file = "aiohttp-3.10.8-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f78e2a78432c537ae876a93013b7bc0027ba5b93ad7b3463624c4b6906489332"},
+    {file = "aiohttp-3.10.8-cp311-cp311-win32.whl", hash = "sha256:f8179855a4e4f3b931cb1764ec87673d3fbdcca2af496c8d30567d7b034a13db"},
+    {file = "aiohttp-3.10.8-cp311-cp311-win_amd64.whl", hash = "sha256:ef9b484604af05ca745b6108ca1aaa22ae1919037ae4f93aaf9a37ba42e0b835"},
+    {file = "aiohttp-3.10.8-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:ab2d6523575fc98896c80f49ac99e849c0b0e69cc80bf864eed6af2ae728a52b"},
+    {file = "aiohttp-3.10.8-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:f5d5d5401744dda50b943d8764508d0e60cc2d3305ac1e6420935861a9d544bc"},
+    {file = "aiohttp-3.10.8-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:de23085cf90911600ace512e909114385026b16324fa203cc74c81f21fd3276a"},
+    {file = "aiohttp-3.10.8-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4618f0d2bf523043866a9ff8458900d8eb0a6d4018f251dae98e5f1fb699f3a8"},
+    {file = "aiohttp-3.10.8-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:21c1925541ca84f7b5e0df361c0a813a7d6a56d3b0030ebd4b220b8d232015f9"},
+    {file = "aiohttp-3.10.8-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:497a7d20caea8855c5429db3cdb829385467217d7feb86952a6107e033e031b9"},
+    {file = "aiohttp-3.10.8-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c887019dbcb4af58a091a45ccf376fffe800b5531b45c1efccda4bedf87747ea"},
+    {file = "aiohttp-3.10.8-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40d2d719c3c36a7a65ed26400e2b45b2d9ed7edf498f4df38b2ae130f25a0d01"},
+    {file = "aiohttp-3.10.8-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:57359785f27394a8bcab0da6dcd46706d087dfebf59a8d0ad2e64a4bc2f6f94f"},
+    {file = "aiohttp-3.10.8-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:a961ee6f2cdd1a2be4735333ab284691180d40bad48f97bb598841bfcbfb94ec"},
+    {file = "aiohttp-3.10.8-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:fe3d79d6af839ffa46fdc5d2cf34295390894471e9875050eafa584cb781508d"},
+    {file = "aiohttp-3.10.8-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:9a281cba03bdaa341c70b7551b2256a88d45eead149f48b75a96d41128c240b3"},
+    {file = "aiohttp-3.10.8-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c6769d71bfb1ed60321363a9bc05e94dcf05e38295ef41d46ac08919e5b00d19"},
+    {file = "aiohttp-3.10.8-cp312-cp312-win32.whl", hash = "sha256:a3081246bab4d419697ee45e555cef5cd1def7ac193dff6f50be761d2e44f194"},
+    {file = "aiohttp-3.10.8-cp312-cp312-win_amd64.whl", hash = "sha256:ab1546fc8e00676febc81c548a876c7bde32f881b8334b77f84719ab2c7d28dc"},
+    {file = "aiohttp-3.10.8-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:b1a012677b8e0a39e181e218de47d6741c5922202e3b0b65e412e2ce47c39337"},
+    {file = "aiohttp-3.10.8-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2df786c96c57cd6b87156ba4c5f166af7b88f3fc05f9d592252fdc83d8615a3c"},
+    {file = "aiohttp-3.10.8-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8885ca09d3a9317219c0831276bfe26984b17b2c37b7bf70dd478d17092a4772"},
+    {file = "aiohttp-3.10.8-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4dbf252ac19860e0ab56cd480d2805498f47c5a2d04f5995d8d8a6effd04b48c"},
+    {file = "aiohttp-3.10.8-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3b2036479b6b94afaaca7d07b8a68dc0e67b0caf5f6293bb6a5a1825f5923000"},
+    {file = "aiohttp-3.10.8-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:365783e1b7c40b59ed4ce2b5a7491bae48f41cd2c30d52647a5b1ee8604c68ad"},
+    {file = "aiohttp-3.10.8-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:270e653b5a4b557476a1ed40e6b6ce82f331aab669620d7c95c658ef976c9c5e"},
+    {file = "aiohttp-3.10.8-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8960fabc20bfe4fafb941067cda8e23c8c17c98c121aa31c7bf0cdab11b07842"},
+    {file = "aiohttp-3.10.8-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f21e8f2abed9a44afc3d15bba22e0dfc71e5fa859bea916e42354c16102b036f"},
+    {file = "aiohttp-3.10.8-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:fecd55e7418fabd297fd836e65cbd6371aa4035a264998a091bbf13f94d9c44d"},
+    {file = "aiohttp-3.10.8-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:badb51d851358cd7535b647bb67af4854b64f3c85f0d089c737f75504d5910ec"},
+    {file = "aiohttp-3.10.8-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:e860985f30f3a015979e63e7ba1a391526cdac1b22b7b332579df7867848e255"},
+    {file = "aiohttp-3.10.8-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:71462f8eeca477cbc0c9700a9464e3f75f59068aed5e9d4a521a103692da72dc"},
+    {file = "aiohttp-3.10.8-cp313-cp313-win32.whl", hash = "sha256:177126e971782769b34933e94fddd1089cef0fe6b82fee8a885e539f5b0f0c6a"},
+    {file = "aiohttp-3.10.8-cp313-cp313-win_amd64.whl", hash = "sha256:98a4eb60e27033dee9593814ca320ee8c199489fbc6b2699d0f710584db7feb7"},
+    {file = "aiohttp-3.10.8-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:ffef3d763e4c8fc97e740da5b4d0f080b78630a3914f4e772a122bbfa608c1db"},
+    {file = "aiohttp-3.10.8-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:597128cb7bc5f068181b49a732961f46cb89f85686206289d6ccb5e27cb5fbe2"},
+    {file = "aiohttp-3.10.8-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f23a6c1d09de5de89a33c9e9b229106cb70dcfdd55e81a3a3580eaadaa32bc92"},
+    {file = "aiohttp-3.10.8-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da57af0c54a302b7c655fa1ccd5b1817a53739afa39924ef1816e7b7c8a07ccb"},
+    {file = "aiohttp-3.10.8-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1e7a6af57091056a79a35104d6ec29d98ec7f1fb7270ad9c6fff871b678d1ff8"},
+    {file = "aiohttp-3.10.8-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:32710d6b3b6c09c60c794d84ca887a3a2890131c0b02b3cefdcc6709a2260a7c"},
+    {file = "aiohttp-3.10.8-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b91f4f62ad39a8a42d511d66269b46cb2fb7dea9564c21ab6c56a642d28bff5"},
+    {file = "aiohttp-3.10.8-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:471a8c47344b9cc309558b3fcc469bd2c12b49322b4b31eb386c4a2b2d44e44a"},
+    {file = "aiohttp-3.10.8-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:fc0e7f91705445d79beafba9bb3057dd50830e40fe5417017a76a214af54e122"},
+    {file = "aiohttp-3.10.8-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:85431c9131a9a0f65260dc7a65c800ca5eae78c4c9931618f18c8e0933a0e0c1"},
+    {file = "aiohttp-3.10.8-cp38-cp38-musllinux_1_2_ppc64le.whl", hash = "sha256:b91557ee0893da52794b25660d4f57bb519bcad8b7df301acd3898f7197c5d81"},
+    {file = "aiohttp-3.10.8-cp38-cp38-musllinux_1_2_s390x.whl", hash = "sha256:4954e6b06dd0be97e1a5751fc606be1f9edbdc553c5d9b57d72406a8fbd17f9d"},
+    {file = "aiohttp-3.10.8-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:a087c84b4992160ffef7afd98ef24177c8bd4ad61c53607145a8377457385100"},
+    {file = "aiohttp-3.10.8-cp38-cp38-win32.whl", hash = "sha256:e1f0f7b27171b2956a27bd8f899751d0866ddabdd05cbddf3520f945130a908c"},
+    {file = "aiohttp-3.10.8-cp38-cp38-win_amd64.whl", hash = "sha256:c4916070e12ae140110aa598031876c1bf8676a36a750716ea0aa5bd694aa2e7"},
+    {file = "aiohttp-3.10.8-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:5284997e3d88d0dfb874c43e51ae8f4a6f4ca5b90dcf22995035187253d430db"},
+    {file = "aiohttp-3.10.8-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9443d9ebc5167ce1fbb552faf2d666fb22ef5716a8750be67efd140a7733738c"},
+    {file = "aiohttp-3.10.8-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b667e2a03407d79a76c618dc30cedebd48f082d85880d0c9c4ec2faa3e10f43e"},
+    {file = "aiohttp-3.10.8-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:98fae99d5c2146f254b7806001498e6f9ffb0e330de55a35e72feb7cb2fa399b"},
+    {file = "aiohttp-3.10.8-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8296edd99d0dd9d0eb8b9e25b3b3506eef55c1854e9cc230f0b3f885f680410b"},
+    {file = "aiohttp-3.10.8-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1ce46dfb49cfbf9e92818be4b761d4042230b1f0e05ffec0aad15b3eb162b905"},
+    {file = "aiohttp-3.10.8-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7c38cfd355fd86c39b2d54651bd6ed7d63d4fe3b5553f364bae3306e2445f847"},
+    {file = "aiohttp-3.10.8-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:713dff3f87ceec3bde4f3f484861464e722cf7533f9fa6b824ec82bb5a9010a7"},
+    {file = "aiohttp-3.10.8-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:21a72f4a9c69a8567a0aca12042f12bba25d3139fd5dd8eeb9931f4d9e8599cd"},
+    {file = "aiohttp-3.10.8-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:6d1ad868624f6cea77341ef2877ad4e71f7116834a6cd7ec36ec5c32f94ee6ae"},
+    {file = "aiohttp-3.10.8-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:a78ba86d5a08207d1d1ad10b97aed6ea48b374b3f6831d02d0b06545ac0f181e"},
+    {file = "aiohttp-3.10.8-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:aff048793d05e1ce05b62e49dccf81fe52719a13f4861530706619506224992b"},
+    {file = "aiohttp-3.10.8-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:d088ca05381fd409793571d8e34eca06daf41c8c50a05aeed358d2d340c7af81"},
+    {file = "aiohttp-3.10.8-cp39-cp39-win32.whl", hash = "sha256:ee97c4e54f457c366e1f76fbbf3e8effee9de57dae671084a161c00f481106ce"},
+    {file = "aiohttp-3.10.8-cp39-cp39-win_amd64.whl", hash = "sha256:d95ae4420669c871667aad92ba8cce6251d61d79c1a38504621094143f94a8b4"},
+    {file = "aiohttp-3.10.8.tar.gz", hash = "sha256:21f8225f7dc187018e8433c9326be01477fb2810721e048b33ac49091b19fb4a"},
 ]
 
 [package.dependencies]
@@ -139,7 +139,7 @@ async-timeout = {version = ">=4.0,<5.0", markers = "python_version < \"3.11\""}
 attrs = ">=17.3.0"
 frozenlist = ">=1.1.1"
 multidict = ">=4.5,<7.0"
-yarl = ">=1.0,<2.0"
+yarl = ">=1.12.0,<2.0"
 
 [package.extras]
 speedups = ["Brotli", "aiodns (>=3.2.0)", "brotlicffi"]
@@ -206,13 +206,13 @@ typing-extensions = {version = ">=4.0.0", markers = "python_version < \"3.9\""}
 
 [[package]]
 name = "anyio"
-version = "4.4.0"
+version = "4.5.0"
 description = "High level compatibility layer for multiple asynchronous event loop implementations"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "anyio-4.4.0-py3-none-any.whl", hash = "sha256:c1b2d8f46a8a812513012e1107cb0e68c17159a7a594208005a57dc776e1bdc7"},
-    {file = "anyio-4.4.0.tar.gz", hash = "sha256:5aadc6a1bbb7cdb0bede386cac5e2940f5e2ff3aa20277e991cf028e0585ce94"},
+    {file = "anyio-4.5.0-py3-none-any.whl", hash = "sha256:fdeb095b7cc5a5563175eedd926ec4ae55413bb4be5770c424af0ba46ccb4a78"},
+    {file = "anyio-4.5.0.tar.gz", hash = "sha256:c5a275fe5ca0afd788001f58fca1e69e29ce706d746e317d660e21f70c530ef9"},
 ]
 
 [package.dependencies]
@@ -222,9 +222,9 @@ sniffio = ">=1.1"
 typing-extensions = {version = ">=4.1", markers = "python_version < \"3.11\""}
 
 [package.extras]
-doc = ["Sphinx (>=7)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx-rtd-theme"]
-test = ["anyio[trio]", "coverage[toml] (>=7)", "exceptiongroup (>=1.2.0)", "hypothesis (>=4.0)", "psutil (>=5.9)", "pytest (>=7.0)", "pytest-mock (>=3.6.1)", "trustme", "uvloop (>=0.17)"]
-trio = ["trio (>=0.23)"]
+doc = ["Sphinx (>=7.4,<8.0)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx-rtd-theme"]
+test = ["anyio[trio]", "coverage[toml] (>=7)", "exceptiongroup (>=1.2.0)", "hypothesis (>=4.0)", "psutil (>=5.9)", "pytest (>=7.0)", "pytest-mock (>=3.6.1)", "trustme", "uvloop (>=0.21.0b1)"]
+trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "async-timeout"
@@ -301,13 +301,13 @@ tzdata = ["tzdata"]
 
 [[package]]
 name = "botocore"
-version = "1.35.16"
+version = "1.35.23"
 description = "Low-level, data-driven core of boto 3."
 optional = true
 python-versions = ">=3.8"
 files = [
-    {file = "botocore-1.35.16-py3-none-any.whl", hash = "sha256:3564a980d95ff2861a6ca74313173d8778aa659125c63cf49c93ad23896c63b1"},
-    {file = "botocore-1.35.16.tar.gz", hash = "sha256:1b48c94e8a4bbe23143f3d1c21a32b9ffc7476b651ef42371ab45d678f6dbfbc"},
+    {file = "botocore-1.35.23-py3-none-any.whl", hash = "sha256:cab9ec4e0367b9f33f0bc02c5a29f587b0119ecffd6d125bacee085dcbc8817d"},
+    {file = "botocore-1.35.23.tar.gz", hash = "sha256:25b17a9ccba6ad32bb5bf7ba4f52656aa03c1cb29f6b4e438050ee4ad1967a3b"},
 ]
 
 [package.dependencies]
@@ -323,13 +323,13 @@ crt = ["awscrt (==0.21.5)"]
 
 [[package]]
 name = "botocore-stubs"
-version = "1.35.22"
+version = "1.35.31"
 description = "Type annotations and code completion for botocore"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "botocore_stubs-1.35.22-py3-none-any.whl", hash = "sha256:dae8cc433df3044ece464f4985e67a154bab51fd042757d0c59e4a9ea26d0376"},
-    {file = "botocore_stubs-1.35.22.tar.gz", hash = "sha256:14dec6b00d974dce4747d6917a791bcea0d8efd1c8959821d8ce6ca69ce40d70"},
+    {file = "botocore_stubs-1.35.31-py3-none-any.whl", hash = "sha256:b7289c27b759dad40759c1421519cbd7ec65b79f7aa8be5dfc76004a61aef42b"},
+    {file = "botocore_stubs-1.35.31.tar.gz", hash = "sha256:b26f79253d8f2460aa8f2d49ae933c3f352fe38be72ea033651c15cd47a822a9"},
 ]
 
 [package.dependencies]
@@ -895,13 +895,13 @@ files = [
 
 [[package]]
 name = "httpcore"
-version = "1.0.5"
+version = "1.0.6"
 description = "A minimal low-level HTTP client."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "httpcore-1.0.5-py3-none-any.whl", hash = "sha256:421f18bac248b25d310f3cacd198d55b8e6125c107797b609ff9b7a6ba7991b5"},
-    {file = "httpcore-1.0.5.tar.gz", hash = "sha256:34a38e2f9291467ee3b44e89dd52615370e152954ba21721378a87b2960f7a61"},
+    {file = "httpcore-1.0.6-py3-none-any.whl", hash = "sha256:27b59625743b85577a8c0e10e55b50b5368a4f2cfe8cc7bcfa9cf00829c2682f"},
+    {file = "httpcore-1.0.6.tar.gz", hash = "sha256:73f6dbd6eb8c21bbf7ef8efad555481853f5f6acdeaff1edb0694289269ee17f"},
 ]
 
 [package.dependencies]
@@ -912,7 +912,7 @@ h11 = ">=0.13,<0.15"
 asyncio = ["anyio (>=4.0,<5.0)"]
 http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (==1.*)"]
-trio = ["trio (>=0.22.0,<0.26.0)"]
+trio = ["trio (>=0.22.0,<1.0)"]
 
 [[package]]
 name = "httpx"
@@ -1065,21 +1065,25 @@ test = ["portend", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-c
 
 [[package]]
 name = "jaraco-functools"
-version = "4.0.2"
+version = "4.1.0"
 description = "Functools like those found in stdlib"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "jaraco.functools-4.0.2-py3-none-any.whl", hash = "sha256:c9d16a3ed4ccb5a889ad8e0b7a343401ee5b2a71cee6ed192d3f68bc351e94e3"},
-    {file = "jaraco_functools-4.0.2.tar.gz", hash = "sha256:3460c74cd0d32bf82b9576bbb3527c4364d5b27a21f5158a62aed6c4b42e23f5"},
+    {file = "jaraco.functools-4.1.0-py3-none-any.whl", hash = "sha256:ad159f13428bc4acbf5541ad6dec511f91573b90fba04df61dafa2a1231cf649"},
+    {file = "jaraco_functools-4.1.0.tar.gz", hash = "sha256:70f7e0e2ae076498e212562325e805204fc092d7b4c17e0e86c959e249701a9d"},
 ]
 
 [package.dependencies]
 more-itertools = "*"
 
 [package.extras]
+check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)"]
+cover = ["pytest-cov"]
 doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-test = ["jaraco.classes", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-ruff (>=0.2.1)"]
+enabler = ["pytest-enabler (>=2.2)"]
+test = ["jaraco.classes", "pytest (>=6,!=8.1.*)"]
+type = ["pytest-mypy"]
 
 [[package]]
 name = "jeepney"
@@ -1126,13 +1130,13 @@ files = [
 
 [[package]]
 name = "keyring"
-version = "25.4.0"
+version = "25.4.1"
 description = "Store and access your passwords safely."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "keyring-25.4.0-py3-none-any.whl", hash = "sha256:a2a630d5c9bef5d3f0968d15ef4e42b894a83e17494edcb67b154c36491c9920"},
-    {file = "keyring-25.4.0.tar.gz", hash = "sha256:ae8263fd9264c94f91ad82d098f8a5bb1b7fa71ce0a72388dc4fc0be3f6a034e"},
+    {file = "keyring-25.4.1-py3-none-any.whl", hash = "sha256:5426f817cf7f6f007ba5ec722b1bcad95a75b27d780343772ad76b17cb47b0bf"},
+    {file = "keyring-25.4.1.tar.gz", hash = "sha256:b07ebc55f3e8ed86ac81dd31ef14e81ace9dd9c3d4b5d77a6e9a2016d0d71a1b"},
 ]
 
 [package.dependencies]
@@ -1152,6 +1156,109 @@ doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linke
 enabler = ["pytest-enabler (>=2.2)"]
 test = ["pyfakefs", "pytest (>=6,!=8.1.*)"]
 type = ["pygobject-stubs", "pytest-mypy", "shtab", "types-pywin32"]
+
+[[package]]
+name = "libvalkey"
+version = "4.0.0"
+description = "Python wrapper for libvalkey"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "libvalkey-4.0.0-cp310-cp310-macosx_10_15_universal2.whl", hash = "sha256:97dbc5018adc0960b7f59c2bbb7234fd430e94c8d23ce3acd71fa0b28228dd98"},
+    {file = "libvalkey-4.0.0-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:8818191a053b6d1f34c4be24091208fe5b2d0739b266ce391aff1fc4a79eb82e"},
+    {file = "libvalkey-4.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6f0a71903033c7020723ba7b6be2bee19da21f295a0664976000dc6070fbf9af"},
+    {file = "libvalkey-4.0.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:463d464e754b5c465eb2d8ce1d109b55081953377955df87fade661921033cdb"},
+    {file = "libvalkey-4.0.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2c37b217cdcc7f9045cbdb57d5b7a29f2df8087b055f8333e0fa857f4d6d483a"},
+    {file = "libvalkey-4.0.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d36f518e1863ef877d6889c22987af877567eecb847e18646b2c28ab8d5501f8"},
+    {file = "libvalkey-4.0.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8024424df89d83fb6ed8048288db870aac41b56b229373a8c559a335e5eec5aa"},
+    {file = "libvalkey-4.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7dc7977e1eca4c3a0db9032f504b5b95251fef13d3a4123913b4ffd52979ea27"},
+    {file = "libvalkey-4.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:1cd48c0fbb1f3a5103d0352a367018488cea7e438616ce573624e4b0c4d585ff"},
+    {file = "libvalkey-4.0.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:57eb009c2b7d6fe262c897638fe1a90d8bd83a2ac5ec24e6bcb967dea7f048ef"},
+    {file = "libvalkey-4.0.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:b835c70ad0d0c132e08f7b503fbfa064b113362fafa99977a59ce63becb5aa15"},
+    {file = "libvalkey-4.0.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:a4fe1000ad3498f01ab3049488ab079fb57c9aec301f42d4110dd3dda525ee60"},
+    {file = "libvalkey-4.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:453a3ec883c8b3c31cd86b525a230cfece4c665683badd27de4ef4294e790bf5"},
+    {file = "libvalkey-4.0.0-cp310-cp310-win32.whl", hash = "sha256:54dda435d9782f51cb9feefa4c1b6d75a0cd323f0360d8ca6b590c2cec852422"},
+    {file = "libvalkey-4.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:aab44979b80888510c7208a0a5b607db38da66aa3cc3cbdca2e75b19d1ae2294"},
+    {file = "libvalkey-4.0.0-cp311-cp311-macosx_10_15_universal2.whl", hash = "sha256:16ee32ba10cb07a5c181e9ab14dd6e06abf4bcb1fe38c71280d97e7a25df85b6"},
+    {file = "libvalkey-4.0.0-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:bb6e3e92d640a2b366de44024c5063edf9f1f8b7d22892d1fd7fad1da165ce9e"},
+    {file = "libvalkey-4.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2b7fca5cc5fec2739054e591fd25fab48128250950018981d63dba1328e165f1"},
+    {file = "libvalkey-4.0.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7457e57a7d618e96e63dac8f2268999b8817d33e9e76f1b409ce552ae71b7e2b"},
+    {file = "libvalkey-4.0.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:aa16938031b16c2deb5d03617346f966f404f754b13e9fd730f4e9d808b98213"},
+    {file = "libvalkey-4.0.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:69eeb03ddd89fb99fbba4085ad4be74b43b921924b7fca9dff9ef343454d0a98"},
+    {file = "libvalkey-4.0.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e22dad7042d090109892b97d41bf51d4ad81be2db2292c3f45ed30686786d604"},
+    {file = "libvalkey-4.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926fe72263924065485ce516f94cb409e93c86351c10743298e44cdfe1bfd7c0"},
+    {file = "libvalkey-4.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4d60a1eb6ae18fb5b06db55d40eb181ce83a9f92735ded6457fda790c716a998"},
+    {file = "libvalkey-4.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:078b00cb30a7a9f5fc93b8f01103eb5d099b7c6d1a2fc7a59bb01e68f29c3684"},
+    {file = "libvalkey-4.0.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f2e16738c756cbf07eee0c3807984cb363873e78d8aef15e47e15153804bdf4c"},
+    {file = "libvalkey-4.0.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:16b02b974dd8520551a4bdf0f66e31262d2f44e894ef04f640c8c59b380a0586"},
+    {file = "libvalkey-4.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:7bc0d7a26d3b1fb0ecc1cd0b935c97017da8f5e9a36b2a108d8fed0fa463c143"},
+    {file = "libvalkey-4.0.0-cp311-cp311-win32.whl", hash = "sha256:73cad7eda136f8163fae0d3994f5bde8e9225a77e2de85a546a8ddca188ac925"},
+    {file = "libvalkey-4.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:0975ceb9440eddd9590f6400a7c32b109f9e45cd48b6d8276bafbbb7cddf4ec3"},
+    {file = "libvalkey-4.0.0-cp312-cp312-macosx_10_15_universal2.whl", hash = "sha256:1c6cadc12cc0197d7a7d6fc8cc321f921b5d87ec218a39839a76c0b284476708"},
+    {file = "libvalkey-4.0.0-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:291d40d277e2d3190955d3b642ec12be8bf9fe160dffa032b83c2b4f1ce71356"},
+    {file = "libvalkey-4.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f2c3fe73a1ba6d9b21cada86156873d161cdd09b69c11aad39d80e45560c447a"},
+    {file = "libvalkey-4.0.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c64ba99ff2084d1b7e90f2fcb891e40848e3f39aa5868bff0dfe1f3f83bbaab2"},
+    {file = "libvalkey-4.0.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:430a9c2d834a1be2ba6dc9d5391baaffb5353860315148cd222138b1480baaf9"},
+    {file = "libvalkey-4.0.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5d11db361d5673659efc4fc3728f92604d8b83de467e377e4da379bec6a5edf7"},
+    {file = "libvalkey-4.0.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9d15ff24f8ef73ab1fa2e608ddc4babfbb68044cbd8e13a6052e8ccbda6adec3"},
+    {file = "libvalkey-4.0.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a43210584746dcccd595920393b41a7e48a30f021b521414d51fd31c0584248b"},
+    {file = "libvalkey-4.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:59fce74dcc7eab247b57e1db890a44388aa7722a5b19a3db1932aa96d1cd8d0f"},
+    {file = "libvalkey-4.0.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:c32f0ca032b6727e2c0b0a8cd0c4590912ab452c61e298f871eff6f660eb1fc9"},
+    {file = "libvalkey-4.0.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:967e22774141da1c92a8a646d8e7024a02670ec94d604f34106f263fe0082188"},
+    {file = "libvalkey-4.0.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:72d1ddfe848b7ec2d4c615316e2b120e0e8a52ded3546b0b5b547d5431fe2ba1"},
+    {file = "libvalkey-4.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:aa334ff652090e6c07d2c3a89320d71479f30efc538c61971b959b1e0267562b"},
+    {file = "libvalkey-4.0.0-cp312-cp312-win32.whl", hash = "sha256:3db84d01d84ca0d3b98a6f88b2ecbfbd1952a03e91c97b13f1e0a138124832a1"},
+    {file = "libvalkey-4.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:9e2aba07c0f7a37432c135f664cae413d31ed00321440c8ac0fed68464f9f420"},
+    {file = "libvalkey-4.0.0-cp38-cp38-macosx_10_15_universal2.whl", hash = "sha256:faa02bb28e478c2623fe26815d7b5d2a7ad68e9fcf3e4466a07777f4d17f6ce0"},
+    {file = "libvalkey-4.0.0-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:d536178df1596c35ac32bcd7836d300f4bc68dc1582ffac8027558442637c0f9"},
+    {file = "libvalkey-4.0.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:6c3a5d8776de930aa6eca1f835d9cd6cb35f0ea0821943d52022f2b75c1f0dbf"},
+    {file = "libvalkey-4.0.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:911b7542c2d33b97e276500f99bb608e112341e41d7922331c11b3e12a77885c"},
+    {file = "libvalkey-4.0.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ca394e737edae7c82ff851f1fa429b9eee11c4fc2cee6336271b318be0afe1f2"},
+    {file = "libvalkey-4.0.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9593e27881e2b848ba81ff546be289af814093a492c4bbb6f837b701d22b802f"},
+    {file = "libvalkey-4.0.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7465dca91e916a9afb94a356bb37750a3715d53de466d30ba9eafaae1b4b4716"},
+    {file = "libvalkey-4.0.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a000914e330559c714b048d53049eb7fe49e556b703a90d037ecc98ff11e6f9b"},
+    {file = "libvalkey-4.0.0-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:5ace17dd14382d1d7286294481f23244e45b8781435aee879f0c0cda8974bf5d"},
+    {file = "libvalkey-4.0.0-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:834bc422727cfb05fe6a360a865751c287e881d32a4b90588ded3b698a6e5eec"},
+    {file = "libvalkey-4.0.0-cp38-cp38-musllinux_1_2_ppc64le.whl", hash = "sha256:735dc00127d9fda43c8d82b929b165172313adb025f4c44c2391a295760b0194"},
+    {file = "libvalkey-4.0.0-cp38-cp38-musllinux_1_2_s390x.whl", hash = "sha256:0025a7cd55afd9421738ee08919788b0f04c60c89a25a8d80d29bce3edea17c9"},
+    {file = "libvalkey-4.0.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:8afffad6e2b9938ea68bcf7a0db53ed288f4c15fe8bd0b7342bd1c3893de9dd7"},
+    {file = "libvalkey-4.0.0-cp38-cp38-win32.whl", hash = "sha256:19ab19e7f387931bb5b974b29959946f01e64122e78706ef4066b38d1cec734f"},
+    {file = "libvalkey-4.0.0-cp38-cp38-win_amd64.whl", hash = "sha256:12f531e13ff901f6cd9fd431977ebbc86e6779dfcb6a52988deafef8774f6b47"},
+    {file = "libvalkey-4.0.0-cp39-cp39-macosx_10_15_universal2.whl", hash = "sha256:a30332e7be16c1043238880135d064f14b8ec30c4e5e7a934d9a4667c14dac15"},
+    {file = "libvalkey-4.0.0-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:359f223c24dfe2e2872f256fe276c3e11842ea04d77e0df1326a0c308632c6d2"},
+    {file = "libvalkey-4.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b629751f4b23f539eabb6060c30f23274c890bb9408a7c674eb9d8b9320dc4b9"},
+    {file = "libvalkey-4.0.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ae9517fef93613b5189fac8849ade4381658ea452774e7a8e9c7ddbf2c5ae57f"},
+    {file = "libvalkey-4.0.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bed1bb33404ca1e225a9557fa438336a25bfd9d94f2dba641c4b8612af19cc2b"},
+    {file = "libvalkey-4.0.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bfd59af8b9142ec22de34f9ff0fb68afcaa8d37f7021bdb935c8fa5d686cd14c"},
+    {file = "libvalkey-4.0.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a8785e9fafb7825fad92e5585aaab615678da84561963e1f0f111bbdc3fbb170"},
+    {file = "libvalkey-4.0.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0dff4f2b1872ab9fe3aaade5fe329238ac54726c7de771c86882838ac9c25334"},
+    {file = "libvalkey-4.0.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:5468fdbe7c478e433a3fd43a0636f6e80a5eb8067fa2ba351396f4ad94d300c0"},
+    {file = "libvalkey-4.0.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:8aea128b12b40afbff59a271bd130a49d8b251e0262047dc933e2098b229a1bf"},
+    {file = "libvalkey-4.0.0-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:8702c9dc4f5fe1f017ca02cfaae86df9be571b41c8707cd316156b301c399865"},
+    {file = "libvalkey-4.0.0-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:647623029d92b407688a9c964bc7ca18e27ef0757f662a0e175a0034fdaeaa07"},
+    {file = "libvalkey-4.0.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:4105120b87ba66f5d95cadfdbd26c9d372df3cd78177e28d9451c151a3f20613"},
+    {file = "libvalkey-4.0.0-cp39-cp39-win32.whl", hash = "sha256:f49b8174cfad6858f0725d9967d7016af851f6b54beb8e1bc2276728e343f631"},
+    {file = "libvalkey-4.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:d381de880b8dbd739a0f3d76d7fbf9d75b244d81e4cdd11880a7128cf7c40301"},
+    {file = "libvalkey-4.0.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0cfec0c9d6d89fdec9467b6fe29430b8f3d36189c4187e3db196860b67e4161c"},
+    {file = "libvalkey-4.0.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:537a6ad812458200d19988789a9e8d75f14d20d1decaf0139286f1cc5258959a"},
+    {file = "libvalkey-4.0.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:832430c53715f16afb2dd2f5ebeaf2e81b3014cd19f587180a470743096c8fc6"},
+    {file = "libvalkey-4.0.0-pp310-pypy310_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8fb034377dffac04e085d881cfe3aa41d698ed3400cc2f1f8f982cf9863f92cf"},
+    {file = "libvalkey-4.0.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3638702abc549bd560c574a9c7f8336980323538498838846b64ad89bb24e513"},
+    {file = "libvalkey-4.0.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:3e880632226ce5192f472a6c427bb560020b4e0cf609fd92504ee89a566d2983"},
+    {file = "libvalkey-4.0.0-pp38-pypy38_pp73-macosx_10_15_x86_64.whl", hash = "sha256:22f9b5fdd2fa52d9f3e3d581794b8e44692de469f181b7549c96571465b1feab"},
+    {file = "libvalkey-4.0.0-pp38-pypy38_pp73-macosx_11_0_arm64.whl", hash = "sha256:6a04d0fe63850c95e1a847043f93825a1d9b04537cf5bde2d12c548acdda17bb"},
+    {file = "libvalkey-4.0.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:51c774997fbd5f16ad6e196d1449cb3eaee171f847148bc2aeb6e52f50134ac9"},
+    {file = "libvalkey-4.0.0-pp38-pypy38_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:92d05d88a1926d2bca72a7cfd55b90f2b2e49c19ba5d4f06620c8e32a312c4fa"},
+    {file = "libvalkey-4.0.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90b6743ddaf96365600bf0df2d928584958e0ac7fac85404dbceedb165992a68"},
+    {file = "libvalkey-4.0.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:4fc803e8d94ef3bbe09d55f81641e0eff35b35519914501973e00d5e549ac976"},
+    {file = "libvalkey-4.0.0-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:e001e72c47e8bc29e18d15f22e4ef3b9d2e52928e9d23471ba9502b0ce67c0d0"},
+    {file = "libvalkey-4.0.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:19a56359350b76a564bd5acf820bcda84d447e3269f316352c5f77c97c7be905"},
+    {file = "libvalkey-4.0.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:65d89f152490086d2145acf79a7b3049aa75ed6e49022e2cb924f04ec404ec6f"},
+    {file = "libvalkey-4.0.0-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b26e2af0b4a36feef67660860ad347a1aa56f85c5bcdb691158aa8999878e9bc"},
+    {file = "libvalkey-4.0.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2d7d17779f099abcdb7a1874c42bb8089231c54a44386643878af11271b73c3"},
+    {file = "libvalkey-4.0.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:f911f95b55144c1c021846c1e62ee9495291d028da39fd33470a7db8c330843a"},
+    {file = "libvalkey-4.0.0.tar.gz", hash = "sha256:b69354798f115f25e4fdccf0b9045baa429a1d55c5c3b653dc3ef2c9e3762807"},
+]
 
 [[package]]
 name = "markdown-it-py"
@@ -1793,21 +1900,23 @@ testing = ["covdefaults (>=2.3)", "pytest (>=8.3.3)", "pytest-cov (>=5)", "pytes
 
 [[package]]
 name = "pyright"
-version = "1.1.381"
+version = "1.1.383"
 description = "Command line wrapper for pyright"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pyright-1.1.381-py3-none-any.whl", hash = "sha256:5dc0aa80a265675d36abab59c674ae01dbe476714f91845b61b841d34aa99081"},
-    {file = "pyright-1.1.381.tar.gz", hash = "sha256:314cf0c1351c189524fb10c7ac20688ecd470e8cc505c394d642c9c80bf7c3a5"},
+    {file = "pyright-1.1.383-py3-none-any.whl", hash = "sha256:d864d1182a313f45aaf99e9bfc7d2668eeabc99b29a556b5344894fd73cb1959"},
+    {file = "pyright-1.1.383.tar.gz", hash = "sha256:1df7f12407f3710c9c6df938d98ec53f70053e6c6bbf71ce7bcb038d42f10070"},
 ]
 
 [package.dependencies]
 nodeenv = ">=1.6.0"
+typing-extensions = ">=4.1"
 
 [package.extras]
-all = ["twine (>=3.4.1)"]
+all = ["nodejs-wheel-binaries", "twine (>=3.4.1)"]
 dev = ["twine (>=3.4.1)"]
+nodejs = ["nodejs-wheel-binaries"]
 
 [[package]]
 name = "pytest"
@@ -1877,21 +1986,21 @@ md = ["cmarkgfm (>=0.8.0)"]
 
 [[package]]
 name = "redis"
-version = "5.0.8"
+version = "5.1.0"
 description = "Python client for Redis database and key-value store"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "redis-5.0.8-py3-none-any.whl", hash = "sha256:56134ee08ea909106090934adc36f65c9bcbbaecea5b21ba704ba6fb561f8eb4"},
-    {file = "redis-5.0.8.tar.gz", hash = "sha256:0c5b10d387568dfe0698c6fad6615750c24170e548ca2deac10c649d463e9870"},
+    {file = "redis-5.1.0-py3-none-any.whl", hash = "sha256:fd4fccba0d7f6aa48c58a78d76ddb4afc698f5da4a2c1d03d916e4fd7ab88cdd"},
+    {file = "redis-5.1.0.tar.gz", hash = "sha256:b756df1e4a3858fcc0ef861f3fc53623a96c41e2b1f5304e09e0fe758d333d40"},
 ]
 
 [package.dependencies]
 async-timeout = {version = ">=4.0.3", markers = "python_full_version < \"3.11.3\""}
 
 [package.extras]
-hiredis = ["hiredis (>1.0.0)"]
-ocsp = ["cryptography (>=36.0.1)", "pyopenssl (==20.0.1)", "requests (>=2.26.0)"]
+hiredis = ["hiredis (>=3.0.0)"]
+ocsp = ["cryptography (>=36.0.1)", "pyopenssl (==23.2.1)", "requests (>=2.31.0)"]
 
 [[package]]
 name = "requests"
@@ -1944,18 +2053,19 @@ idna2008 = ["idna"]
 
 [[package]]
 name = "rich"
-version = "13.8.1"
+version = "13.9.1"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
 optional = false
-python-versions = ">=3.7.0"
+python-versions = ">=3.8.0"
 files = [
-    {file = "rich-13.8.1-py3-none-any.whl", hash = "sha256:1760a3c0848469b97b558fc61c85233e3dafb69c7a071b4d60c38099d3cd4c06"},
-    {file = "rich-13.8.1.tar.gz", hash = "sha256:8260cda28e3db6bf04d2d1ef4dbc03ba80a824c88b0e7668a0f23126a424844a"},
+    {file = "rich-13.9.1-py3-none-any.whl", hash = "sha256:b340e739f30aa58921dc477b8adaa9ecdb7cecc217be01d93730ee1bc8aa83be"},
+    {file = "rich-13.9.1.tar.gz", hash = "sha256:097cffdf85db1babe30cc7deba5ab3a29e1b9885047dab24c57e9a7f8a9c1466"},
 ]
 
 [package.dependencies]
 markdown-it-py = ">=2.2.0"
 pygments = ">=2.13.0,<3.0.0"
+typing-extensions = {version = ">=4.0.0,<5.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 jupyter = ["ipywidgets (>=7.5.1,<9)"]
@@ -2045,13 +2155,13 @@ files = [
 
 [[package]]
 name = "starlette"
-version = "0.38.5"
+version = "0.38.6"
 description = "The little ASGI library that shines."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "starlette-0.38.5-py3-none-any.whl", hash = "sha256:632f420a9d13e3ee2a6f18f437b0a9f1faecb0bc42e1942aa2ea0e379a4c4206"},
-    {file = "starlette-0.38.5.tar.gz", hash = "sha256:04a92830a9b6eb1442c766199d62260c3d4dc9c4f9188360626b1e0273cb7077"},
+    {file = "starlette-0.38.6-py3-none-any.whl", hash = "sha256:4517a1409e2e73ee4951214ba012052b9e16f60e90d73cfb06192c19203bbb05"},
+    {file = "starlette-0.38.6.tar.gz", hash = "sha256:863a1588f5574e70a821dadefb41e4881ea451a47a3cd1b4df359d4ffefe5ead"},
 ]
 
 [package.dependencies]
@@ -2063,13 +2173,13 @@ full = ["httpx (>=0.22.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.7
 
 [[package]]
 name = "tomli"
-version = "2.0.1"
+version = "2.0.2"
 description = "A lil' TOML parser"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
-    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+    {file = "tomli-2.0.2-py3-none-any.whl", hash = "sha256:2ebe24485c53d303f690b0ec092806a085f07af5a5aa1464f3931eec36caaa38"},
+    {file = "tomli-2.0.2.tar.gz", hash = "sha256:d46d457a85337051c36524bc5349dd91b1877838e2979ac5ced3e710ed8a60ed"},
 ]
 
 [[package]]
@@ -2096,30 +2206,31 @@ dev = ["furo", "packaging", "sphinx (>=5)", "twisted"]
 
 [[package]]
 name = "tox"
-version = "4.20.0"
+version = "4.21.0"
 description = "tox is a generic virtualenv management and test command line tool"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "tox-4.20.0-py3-none-any.whl", hash = "sha256:21a8005e3d3fe5658a8e36b8ca3ed13a4230429063c5cc2a2fdac6ee5aa0de34"},
-    {file = "tox-4.20.0.tar.gz", hash = "sha256:5b78a49b6eaaeab3ae4186415e7c97d524f762ae967c63562687c3e5f0ec23d5"},
+    {file = "tox-4.21.0-py3-none-any.whl", hash = "sha256:693ac51378255d34ad7aab6dd2ce9ab6a1cf1924eb930183fde850ad503b681d"},
+    {file = "tox-4.21.0.tar.gz", hash = "sha256:e64dd9847ff3a7ec90368be412d7efe61a39caf043222ffbe9ad638ea435f6f6"},
 ]
 
 [package.dependencies]
 cachetools = ">=5.5"
 chardet = ">=5.2"
 colorama = ">=0.4.6"
-filelock = ">=3.15.4"
+filelock = ">=3.16.1"
 packaging = ">=24.1"
-platformdirs = ">=4.2.2"
+platformdirs = ">=4.3.6"
 pluggy = ">=1.5"
-pyproject-api = ">=1.7.1"
+pyproject-api = ">=1.8"
 tomli = {version = ">=2.0.1", markers = "python_version < \"3.11\""}
-virtualenv = ">=20.26.3"
+typing-extensions = {version = ">=4.12.2", markers = "python_version < \"3.11\""}
+virtualenv = ">=20.26.6"
 
 [package.extras]
-docs = ["furo (>=2024.8.6)", "sphinx (>=8.0.2)", "sphinx-argparse-cli (>=1.17)", "sphinx-autodoc-typehints (>=2.4)", "sphinx-copybutton (>=0.5.2)", "sphinx-inline-tabs (>=2023.4.21)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=24.8)"]
-testing = ["build[virtualenv] (>=1.2.2)", "covdefaults (>=2.3)", "detect-test-pollution (>=1.2)", "devpi-process (>=1)", "diff-cover (>=9.1.1)", "distlib (>=0.3.8)", "flaky (>=3.8.1)", "hatch-vcs (>=0.4)", "hatchling (>=1.25)", "psutil (>=6)", "pytest (>=8.3.2)", "pytest-cov (>=5)", "pytest-mock (>=3.14)", "pytest-xdist (>=3.6.1)", "re-assert (>=1.1)", "setuptools (>=74.1.2)", "time-machine (>=2.15)", "wheel (>=0.44)"]
+docs = ["furo (>=2024.8.6)", "sphinx (>=8.0.2)", "sphinx-argparse-cli (>=1.18.2)", "sphinx-autodoc-typehints (>=2.4.4)", "sphinx-copybutton (>=0.5.2)", "sphinx-inline-tabs (>=2023.4.21)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=24.8)"]
+testing = ["build[virtualenv] (>=1.2.2)", "covdefaults (>=2.3)", "detect-test-pollution (>=1.2)", "devpi-process (>=1.0.2)", "diff-cover (>=9.2)", "distlib (>=0.3.8)", "flaky (>=3.8.1)", "hatch-vcs (>=0.4)", "hatchling (>=1.25)", "psutil (>=6)", "pytest (>=8.3.3)", "pytest-cov (>=5)", "pytest-mock (>=3.14)", "pytest-xdist (>=3.6.1)", "re-assert (>=1.1)", "setuptools (>=75.1)", "time-machine (>=2.15)", "wheel (>=0.44)"]
 
 [[package]]
 name = "twine"
@@ -2145,13 +2256,13 @@ urllib3 = ">=1.26.0"
 
 [[package]]
 name = "types-aiobotocore"
-version = "2.15.0"
-description = "Type annotations for aiobotocore 2.15.0 generated with mypy-boto3-builder 8.0.1"
+version = "2.15.1"
+description = "Type annotations for aiobotocore 2.15.1 generated with mypy-boto3-builder 8.1.2"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "types_aiobotocore-2.15.0-py3-none-any.whl", hash = "sha256:a3b9ccfb7f1a7689af564f7e9079ac76d701a1b0757cf6235de433520bdfae80"},
-    {file = "types_aiobotocore-2.15.0.tar.gz", hash = "sha256:eb9c21780cab3887baaf0ae3ca02c5fe0ab7b988f4a9a5c43e7aff2f894d7ca7"},
+    {file = "types_aiobotocore-2.15.1-py3-none-any.whl", hash = "sha256:5d4546c0dac02c7c4473b033cccabb4776b0d3fd049faaf964a644ed0d6ecf28"},
+    {file = "types_aiobotocore-2.15.1.tar.gz", hash = "sha256:0d6ed0c8456fbe59dec345aa142800db0837b98bca1ed5f68cf6ef6d52137745"},
 ]
 
 [package.dependencies]
@@ -2164,8 +2275,8 @@ accessanalyzer = ["types-aiobotocore-accessanalyzer (>=2.15.0,<2.16.0)"]
 account = ["types-aiobotocore-account (>=2.15.0,<2.16.0)"]
 acm = ["types-aiobotocore-acm (>=2.15.0,<2.16.0)"]
 acm-pca = ["types-aiobotocore-acm-pca (>=2.15.0,<2.16.0)"]
-aiobotocore = ["aiobotocore (==2.15.0)", "botocore (==1.35.16)"]
-all = ["types-aiobotocore-accessanalyzer (>=2.15.0,<2.16.0)", "types-aiobotocore-account (>=2.15.0,<2.16.0)", "types-aiobotocore-acm (>=2.15.0,<2.16.0)", "types-aiobotocore-acm-pca (>=2.15.0,<2.16.0)", "types-aiobotocore-amp (>=2.15.0,<2.16.0)", "types-aiobotocore-amplify (>=2.15.0,<2.16.0)", "types-aiobotocore-amplifybackend (>=2.15.0,<2.16.0)", "types-aiobotocore-amplifyuibuilder (>=2.15.0,<2.16.0)", "types-aiobotocore-apigateway (>=2.15.0,<2.16.0)", "types-aiobotocore-apigatewaymanagementapi (>=2.15.0,<2.16.0)", "types-aiobotocore-apigatewayv2 (>=2.15.0,<2.16.0)", "types-aiobotocore-appconfig (>=2.15.0,<2.16.0)", "types-aiobotocore-appconfigdata (>=2.15.0,<2.16.0)", "types-aiobotocore-appfabric (>=2.15.0,<2.16.0)", "types-aiobotocore-appflow (>=2.15.0,<2.16.0)", "types-aiobotocore-appintegrations (>=2.15.0,<2.16.0)", "types-aiobotocore-application-autoscaling (>=2.15.0,<2.16.0)", "types-aiobotocore-application-insights (>=2.15.0,<2.16.0)", "types-aiobotocore-application-signals (>=2.15.0,<2.16.0)", "types-aiobotocore-applicationcostprofiler (>=2.15.0,<2.16.0)", "types-aiobotocore-appmesh (>=2.15.0,<2.16.0)", "types-aiobotocore-apprunner (>=2.15.0,<2.16.0)", "types-aiobotocore-appstream (>=2.15.0,<2.16.0)", "types-aiobotocore-appsync (>=2.15.0,<2.16.0)", "types-aiobotocore-apptest (>=2.15.0,<2.16.0)", "types-aiobotocore-arc-zonal-shift (>=2.15.0,<2.16.0)", "types-aiobotocore-artifact (>=2.15.0,<2.16.0)", "types-aiobotocore-athena (>=2.15.0,<2.16.0)", "types-aiobotocore-auditmanager (>=2.15.0,<2.16.0)", "types-aiobotocore-autoscaling (>=2.15.0,<2.16.0)", "types-aiobotocore-autoscaling-plans (>=2.15.0,<2.16.0)", "types-aiobotocore-b2bi (>=2.15.0,<2.16.0)", "types-aiobotocore-backup (>=2.15.0,<2.16.0)", "types-aiobotocore-backup-gateway (>=2.15.0,<2.16.0)", "types-aiobotocore-batch (>=2.15.0,<2.16.0)", "types-aiobotocore-bcm-data-exports (>=2.15.0,<2.16.0)", "types-aiobotocore-bedrock (>=2.15.0,<2.16.0)", "types-aiobotocore-bedrock-agent (>=2.15.0,<2.16.0)", "types-aiobotocore-bedrock-agent-runtime (>=2.15.0,<2.16.0)", "types-aiobotocore-bedrock-runtime (>=2.15.0,<2.16.0)", "types-aiobotocore-billingconductor (>=2.15.0,<2.16.0)", "types-aiobotocore-braket (>=2.15.0,<2.16.0)", "types-aiobotocore-budgets (>=2.15.0,<2.16.0)", "types-aiobotocore-ce (>=2.15.0,<2.16.0)", "types-aiobotocore-chatbot (>=2.15.0,<2.16.0)", "types-aiobotocore-chime (>=2.15.0,<2.16.0)", "types-aiobotocore-chime-sdk-identity (>=2.15.0,<2.16.0)", "types-aiobotocore-chime-sdk-media-pipelines (>=2.15.0,<2.16.0)", "types-aiobotocore-chime-sdk-meetings (>=2.15.0,<2.16.0)", "types-aiobotocore-chime-sdk-messaging (>=2.15.0,<2.16.0)", "types-aiobotocore-chime-sdk-voice (>=2.15.0,<2.16.0)", "types-aiobotocore-cleanrooms (>=2.15.0,<2.16.0)", "types-aiobotocore-cleanroomsml (>=2.15.0,<2.16.0)", "types-aiobotocore-cloud9 (>=2.15.0,<2.16.0)", "types-aiobotocore-cloudcontrol (>=2.15.0,<2.16.0)", "types-aiobotocore-clouddirectory (>=2.15.0,<2.16.0)", "types-aiobotocore-cloudformation (>=2.15.0,<2.16.0)", "types-aiobotocore-cloudfront (>=2.15.0,<2.16.0)", "types-aiobotocore-cloudfront-keyvaluestore (>=2.15.0,<2.16.0)", "types-aiobotocore-cloudhsm (>=2.15.0,<2.16.0)", "types-aiobotocore-cloudhsmv2 (>=2.15.0,<2.16.0)", "types-aiobotocore-cloudsearch (>=2.15.0,<2.16.0)", "types-aiobotocore-cloudsearchdomain (>=2.15.0,<2.16.0)", "types-aiobotocore-cloudtrail (>=2.15.0,<2.16.0)", "types-aiobotocore-cloudtrail-data (>=2.15.0,<2.16.0)", "types-aiobotocore-cloudwatch (>=2.15.0,<2.16.0)", "types-aiobotocore-codeartifact (>=2.15.0,<2.16.0)", "types-aiobotocore-codebuild (>=2.15.0,<2.16.0)", "types-aiobotocore-codecatalyst (>=2.15.0,<2.16.0)", "types-aiobotocore-codecommit (>=2.15.0,<2.16.0)", "types-aiobotocore-codeconnections (>=2.15.0,<2.16.0)", "types-aiobotocore-codedeploy (>=2.15.0,<2.16.0)", "types-aiobotocore-codeguru-reviewer (>=2.15.0,<2.16.0)", "types-aiobotocore-codeguru-security (>=2.15.0,<2.16.0)", "types-aiobotocore-codeguruprofiler (>=2.15.0,<2.16.0)", "types-aiobotocore-codepipeline (>=2.15.0,<2.16.0)", "types-aiobotocore-codestar-connections (>=2.15.0,<2.16.0)", "types-aiobotocore-codestar-notifications (>=2.15.0,<2.16.0)", "types-aiobotocore-cognito-identity (>=2.15.0,<2.16.0)", "types-aiobotocore-cognito-idp (>=2.15.0,<2.16.0)", "types-aiobotocore-cognito-sync (>=2.15.0,<2.16.0)", "types-aiobotocore-comprehend (>=2.15.0,<2.16.0)", "types-aiobotocore-comprehendmedical (>=2.15.0,<2.16.0)", "types-aiobotocore-compute-optimizer (>=2.15.0,<2.16.0)", "types-aiobotocore-config (>=2.15.0,<2.16.0)", "types-aiobotocore-connect (>=2.15.0,<2.16.0)", "types-aiobotocore-connect-contact-lens (>=2.15.0,<2.16.0)", "types-aiobotocore-connectcampaigns (>=2.15.0,<2.16.0)", "types-aiobotocore-connectcases (>=2.15.0,<2.16.0)", "types-aiobotocore-connectparticipant (>=2.15.0,<2.16.0)", "types-aiobotocore-controlcatalog (>=2.15.0,<2.16.0)", "types-aiobotocore-controltower (>=2.15.0,<2.16.0)", "types-aiobotocore-cost-optimization-hub (>=2.15.0,<2.16.0)", "types-aiobotocore-cur (>=2.15.0,<2.16.0)", "types-aiobotocore-customer-profiles (>=2.15.0,<2.16.0)", "types-aiobotocore-databrew (>=2.15.0,<2.16.0)", "types-aiobotocore-dataexchange (>=2.15.0,<2.16.0)", "types-aiobotocore-datapipeline (>=2.15.0,<2.16.0)", "types-aiobotocore-datasync (>=2.15.0,<2.16.0)", "types-aiobotocore-datazone (>=2.15.0,<2.16.0)", "types-aiobotocore-dax (>=2.15.0,<2.16.0)", "types-aiobotocore-deadline (>=2.15.0,<2.16.0)", "types-aiobotocore-detective (>=2.15.0,<2.16.0)", "types-aiobotocore-devicefarm (>=2.15.0,<2.16.0)", "types-aiobotocore-devops-guru (>=2.15.0,<2.16.0)", "types-aiobotocore-directconnect (>=2.15.0,<2.16.0)", "types-aiobotocore-discovery (>=2.15.0,<2.16.0)", "types-aiobotocore-dlm (>=2.15.0,<2.16.0)", "types-aiobotocore-dms (>=2.15.0,<2.16.0)", "types-aiobotocore-docdb (>=2.15.0,<2.16.0)", "types-aiobotocore-docdb-elastic (>=2.15.0,<2.16.0)", "types-aiobotocore-drs (>=2.15.0,<2.16.0)", "types-aiobotocore-ds (>=2.15.0,<2.16.0)", "types-aiobotocore-dynamodb (>=2.15.0,<2.16.0)", "types-aiobotocore-dynamodbstreams (>=2.15.0,<2.16.0)", "types-aiobotocore-ebs (>=2.15.0,<2.16.0)", "types-aiobotocore-ec2 (>=2.15.0,<2.16.0)", "types-aiobotocore-ec2-instance-connect (>=2.15.0,<2.16.0)", "types-aiobotocore-ecr (>=2.15.0,<2.16.0)", "types-aiobotocore-ecr-public (>=2.15.0,<2.16.0)", "types-aiobotocore-ecs (>=2.15.0,<2.16.0)", "types-aiobotocore-efs (>=2.15.0,<2.16.0)", "types-aiobotocore-eks (>=2.15.0,<2.16.0)", "types-aiobotocore-eks-auth (>=2.15.0,<2.16.0)", "types-aiobotocore-elastic-inference (>=2.15.0,<2.16.0)", "types-aiobotocore-elasticache (>=2.15.0,<2.16.0)", "types-aiobotocore-elasticbeanstalk (>=2.15.0,<2.16.0)", "types-aiobotocore-elastictranscoder (>=2.15.0,<2.16.0)", "types-aiobotocore-elb (>=2.15.0,<2.16.0)", "types-aiobotocore-elbv2 (>=2.15.0,<2.16.0)", "types-aiobotocore-emr (>=2.15.0,<2.16.0)", "types-aiobotocore-emr-containers (>=2.15.0,<2.16.0)", "types-aiobotocore-emr-serverless (>=2.15.0,<2.16.0)", "types-aiobotocore-entityresolution (>=2.15.0,<2.16.0)", "types-aiobotocore-es (>=2.15.0,<2.16.0)", "types-aiobotocore-events (>=2.15.0,<2.16.0)", "types-aiobotocore-evidently (>=2.15.0,<2.16.0)", "types-aiobotocore-finspace (>=2.15.0,<2.16.0)", "types-aiobotocore-finspace-data (>=2.15.0,<2.16.0)", "types-aiobotocore-firehose (>=2.15.0,<2.16.0)", "types-aiobotocore-fis (>=2.15.0,<2.16.0)", "types-aiobotocore-fms (>=2.15.0,<2.16.0)", "types-aiobotocore-forecast (>=2.15.0,<2.16.0)", "types-aiobotocore-forecastquery (>=2.15.0,<2.16.0)", "types-aiobotocore-frauddetector (>=2.15.0,<2.16.0)", "types-aiobotocore-freetier (>=2.15.0,<2.16.0)", "types-aiobotocore-fsx (>=2.15.0,<2.16.0)", "types-aiobotocore-gamelift (>=2.15.0,<2.16.0)", "types-aiobotocore-glacier (>=2.15.0,<2.16.0)", "types-aiobotocore-globalaccelerator (>=2.15.0,<2.16.0)", "types-aiobotocore-glue (>=2.15.0,<2.16.0)", "types-aiobotocore-grafana (>=2.15.0,<2.16.0)", "types-aiobotocore-greengrass (>=2.15.0,<2.16.0)", "types-aiobotocore-greengrassv2 (>=2.15.0,<2.16.0)", "types-aiobotocore-groundstation (>=2.15.0,<2.16.0)", "types-aiobotocore-guardduty (>=2.15.0,<2.16.0)", "types-aiobotocore-health (>=2.15.0,<2.16.0)", "types-aiobotocore-healthlake (>=2.15.0,<2.16.0)", "types-aiobotocore-iam (>=2.15.0,<2.16.0)", "types-aiobotocore-identitystore (>=2.15.0,<2.16.0)", "types-aiobotocore-imagebuilder (>=2.15.0,<2.16.0)", "types-aiobotocore-importexport (>=2.15.0,<2.16.0)", "types-aiobotocore-inspector (>=2.15.0,<2.16.0)", "types-aiobotocore-inspector-scan (>=2.15.0,<2.16.0)", "types-aiobotocore-inspector2 (>=2.15.0,<2.16.0)", "types-aiobotocore-internetmonitor (>=2.15.0,<2.16.0)", "types-aiobotocore-iot (>=2.15.0,<2.16.0)", "types-aiobotocore-iot-data (>=2.15.0,<2.16.0)", "types-aiobotocore-iot-jobs-data (>=2.15.0,<2.16.0)", "types-aiobotocore-iot1click-devices (>=2.15.0,<2.16.0)", "types-aiobotocore-iot1click-projects (>=2.15.0,<2.16.0)", "types-aiobotocore-iotanalytics (>=2.15.0,<2.16.0)", "types-aiobotocore-iotdeviceadvisor (>=2.15.0,<2.16.0)", "types-aiobotocore-iotevents (>=2.15.0,<2.16.0)", "types-aiobotocore-iotevents-data (>=2.15.0,<2.16.0)", "types-aiobotocore-iotfleethub (>=2.15.0,<2.16.0)", "types-aiobotocore-iotfleetwise (>=2.15.0,<2.16.0)", "types-aiobotocore-iotsecuretunneling (>=2.15.0,<2.16.0)", "types-aiobotocore-iotsitewise (>=2.15.0,<2.16.0)", "types-aiobotocore-iotthingsgraph (>=2.15.0,<2.16.0)", "types-aiobotocore-iottwinmaker (>=2.15.0,<2.16.0)", "types-aiobotocore-iotwireless (>=2.15.0,<2.16.0)", "types-aiobotocore-ivs (>=2.15.0,<2.16.0)", "types-aiobotocore-ivs-realtime (>=2.15.0,<2.16.0)", "types-aiobotocore-ivschat (>=2.15.0,<2.16.0)", "types-aiobotocore-kafka (>=2.15.0,<2.16.0)", "types-aiobotocore-kafkaconnect (>=2.15.0,<2.16.0)", "types-aiobotocore-kendra (>=2.15.0,<2.16.0)", "types-aiobotocore-kendra-ranking (>=2.15.0,<2.16.0)", "types-aiobotocore-keyspaces (>=2.15.0,<2.16.0)", "types-aiobotocore-kinesis (>=2.15.0,<2.16.0)", "types-aiobotocore-kinesis-video-archived-media (>=2.15.0,<2.16.0)", "types-aiobotocore-kinesis-video-media (>=2.15.0,<2.16.0)", "types-aiobotocore-kinesis-video-signaling (>=2.15.0,<2.16.0)", "types-aiobotocore-kinesis-video-webrtc-storage (>=2.15.0,<2.16.0)", "types-aiobotocore-kinesisanalytics (>=2.15.0,<2.16.0)", "types-aiobotocore-kinesisanalyticsv2 (>=2.15.0,<2.16.0)", "types-aiobotocore-kinesisvideo (>=2.15.0,<2.16.0)", "types-aiobotocore-kms (>=2.15.0,<2.16.0)", "types-aiobotocore-lakeformation (>=2.15.0,<2.16.0)", "types-aiobotocore-lambda (>=2.15.0,<2.16.0)", "types-aiobotocore-launch-wizard (>=2.15.0,<2.16.0)", "types-aiobotocore-lex-models (>=2.15.0,<2.16.0)", "types-aiobotocore-lex-runtime (>=2.15.0,<2.16.0)", "types-aiobotocore-lexv2-models (>=2.15.0,<2.16.0)", "types-aiobotocore-lexv2-runtime (>=2.15.0,<2.16.0)", "types-aiobotocore-license-manager (>=2.15.0,<2.16.0)", "types-aiobotocore-license-manager-linux-subscriptions (>=2.15.0,<2.16.0)", "types-aiobotocore-license-manager-user-subscriptions (>=2.15.0,<2.16.0)", "types-aiobotocore-lightsail (>=2.15.0,<2.16.0)", "types-aiobotocore-location (>=2.15.0,<2.16.0)", "types-aiobotocore-logs (>=2.15.0,<2.16.0)", "types-aiobotocore-lookoutequipment (>=2.15.0,<2.16.0)", "types-aiobotocore-lookoutmetrics (>=2.15.0,<2.16.0)", "types-aiobotocore-lookoutvision (>=2.15.0,<2.16.0)", "types-aiobotocore-m2 (>=2.15.0,<2.16.0)", "types-aiobotocore-machinelearning (>=2.15.0,<2.16.0)", "types-aiobotocore-macie2 (>=2.15.0,<2.16.0)", "types-aiobotocore-mailmanager (>=2.15.0,<2.16.0)", "types-aiobotocore-managedblockchain (>=2.15.0,<2.16.0)", "types-aiobotocore-managedblockchain-query (>=2.15.0,<2.16.0)", "types-aiobotocore-marketplace-agreement (>=2.15.0,<2.16.0)", "types-aiobotocore-marketplace-catalog (>=2.15.0,<2.16.0)", "types-aiobotocore-marketplace-deployment (>=2.15.0,<2.16.0)", "types-aiobotocore-marketplace-entitlement (>=2.15.0,<2.16.0)", "types-aiobotocore-marketplacecommerceanalytics (>=2.15.0,<2.16.0)", "types-aiobotocore-mediaconnect (>=2.15.0,<2.16.0)", "types-aiobotocore-mediaconvert (>=2.15.0,<2.16.0)", "types-aiobotocore-medialive (>=2.15.0,<2.16.0)", "types-aiobotocore-mediapackage (>=2.15.0,<2.16.0)", "types-aiobotocore-mediapackage-vod (>=2.15.0,<2.16.0)", "types-aiobotocore-mediapackagev2 (>=2.15.0,<2.16.0)", "types-aiobotocore-mediastore (>=2.15.0,<2.16.0)", "types-aiobotocore-mediastore-data (>=2.15.0,<2.16.0)", "types-aiobotocore-mediatailor (>=2.15.0,<2.16.0)", "types-aiobotocore-medical-imaging (>=2.15.0,<2.16.0)", "types-aiobotocore-memorydb (>=2.15.0,<2.16.0)", "types-aiobotocore-meteringmarketplace (>=2.15.0,<2.16.0)", "types-aiobotocore-mgh (>=2.15.0,<2.16.0)", "types-aiobotocore-mgn (>=2.15.0,<2.16.0)", "types-aiobotocore-migration-hub-refactor-spaces (>=2.15.0,<2.16.0)", "types-aiobotocore-migrationhub-config (>=2.15.0,<2.16.0)", "types-aiobotocore-migrationhuborchestrator (>=2.15.0,<2.16.0)", "types-aiobotocore-migrationhubstrategy (>=2.15.0,<2.16.0)", "types-aiobotocore-mq (>=2.15.0,<2.16.0)", "types-aiobotocore-mturk (>=2.15.0,<2.16.0)", "types-aiobotocore-mwaa (>=2.15.0,<2.16.0)", "types-aiobotocore-neptune (>=2.15.0,<2.16.0)", "types-aiobotocore-neptune-graph (>=2.15.0,<2.16.0)", "types-aiobotocore-neptunedata (>=2.15.0,<2.16.0)", "types-aiobotocore-network-firewall (>=2.15.0,<2.16.0)", "types-aiobotocore-networkmanager (>=2.15.0,<2.16.0)", "types-aiobotocore-networkmonitor (>=2.15.0,<2.16.0)", "types-aiobotocore-nimble (>=2.15.0,<2.16.0)", "types-aiobotocore-oam (>=2.15.0,<2.16.0)", "types-aiobotocore-omics (>=2.15.0,<2.16.0)", "types-aiobotocore-opensearch (>=2.15.0,<2.16.0)", "types-aiobotocore-opensearchserverless (>=2.15.0,<2.16.0)", "types-aiobotocore-opsworks (>=2.15.0,<2.16.0)", "types-aiobotocore-opsworkscm (>=2.15.0,<2.16.0)", "types-aiobotocore-organizations (>=2.15.0,<2.16.0)", "types-aiobotocore-osis (>=2.15.0,<2.16.0)", "types-aiobotocore-outposts (>=2.15.0,<2.16.0)", "types-aiobotocore-panorama (>=2.15.0,<2.16.0)", "types-aiobotocore-payment-cryptography (>=2.15.0,<2.16.0)", "types-aiobotocore-payment-cryptography-data (>=2.15.0,<2.16.0)", "types-aiobotocore-pca-connector-ad (>=2.15.0,<2.16.0)", "types-aiobotocore-pca-connector-scep (>=2.15.0,<2.16.0)", "types-aiobotocore-pcs (>=2.15.0,<2.16.0)", "types-aiobotocore-personalize (>=2.15.0,<2.16.0)", "types-aiobotocore-personalize-events (>=2.15.0,<2.16.0)", "types-aiobotocore-personalize-runtime (>=2.15.0,<2.16.0)", "types-aiobotocore-pi (>=2.15.0,<2.16.0)", "types-aiobotocore-pinpoint (>=2.15.0,<2.16.0)", "types-aiobotocore-pinpoint-email (>=2.15.0,<2.16.0)", "types-aiobotocore-pinpoint-sms-voice (>=2.15.0,<2.16.0)", "types-aiobotocore-pinpoint-sms-voice-v2 (>=2.15.0,<2.16.0)", "types-aiobotocore-pipes (>=2.15.0,<2.16.0)", "types-aiobotocore-polly (>=2.15.0,<2.16.0)", "types-aiobotocore-pricing (>=2.15.0,<2.16.0)", "types-aiobotocore-privatenetworks (>=2.15.0,<2.16.0)", "types-aiobotocore-proton (>=2.15.0,<2.16.0)", "types-aiobotocore-qapps (>=2.15.0,<2.16.0)", "types-aiobotocore-qbusiness (>=2.15.0,<2.16.0)", "types-aiobotocore-qconnect (>=2.15.0,<2.16.0)", "types-aiobotocore-qldb (>=2.15.0,<2.16.0)", "types-aiobotocore-qldb-session (>=2.15.0,<2.16.0)", "types-aiobotocore-quicksight (>=2.15.0,<2.16.0)", "types-aiobotocore-ram (>=2.15.0,<2.16.0)", "types-aiobotocore-rbin (>=2.15.0,<2.16.0)", "types-aiobotocore-rds (>=2.15.0,<2.16.0)", "types-aiobotocore-rds-data (>=2.15.0,<2.16.0)", "types-aiobotocore-redshift (>=2.15.0,<2.16.0)", "types-aiobotocore-redshift-data (>=2.15.0,<2.16.0)", "types-aiobotocore-redshift-serverless (>=2.15.0,<2.16.0)", "types-aiobotocore-rekognition (>=2.15.0,<2.16.0)", "types-aiobotocore-repostspace (>=2.15.0,<2.16.0)", "types-aiobotocore-resiliencehub (>=2.15.0,<2.16.0)", "types-aiobotocore-resource-explorer-2 (>=2.15.0,<2.16.0)", "types-aiobotocore-resource-groups (>=2.15.0,<2.16.0)", "types-aiobotocore-resourcegroupstaggingapi (>=2.15.0,<2.16.0)", "types-aiobotocore-robomaker (>=2.15.0,<2.16.0)", "types-aiobotocore-rolesanywhere (>=2.15.0,<2.16.0)", "types-aiobotocore-route53 (>=2.15.0,<2.16.0)", "types-aiobotocore-route53-recovery-cluster (>=2.15.0,<2.16.0)", "types-aiobotocore-route53-recovery-control-config (>=2.15.0,<2.16.0)", "types-aiobotocore-route53-recovery-readiness (>=2.15.0,<2.16.0)", "types-aiobotocore-route53domains (>=2.15.0,<2.16.0)", "types-aiobotocore-route53profiles (>=2.15.0,<2.16.0)", "types-aiobotocore-route53resolver (>=2.15.0,<2.16.0)", "types-aiobotocore-rum (>=2.15.0,<2.16.0)", "types-aiobotocore-s3 (>=2.15.0,<2.16.0)", "types-aiobotocore-s3control (>=2.15.0,<2.16.0)", "types-aiobotocore-s3outposts (>=2.15.0,<2.16.0)", "types-aiobotocore-sagemaker (>=2.15.0,<2.16.0)", "types-aiobotocore-sagemaker-a2i-runtime (>=2.15.0,<2.16.0)", "types-aiobotocore-sagemaker-edge (>=2.15.0,<2.16.0)", "types-aiobotocore-sagemaker-featurestore-runtime (>=2.15.0,<2.16.0)", "types-aiobotocore-sagemaker-geospatial (>=2.15.0,<2.16.0)", "types-aiobotocore-sagemaker-metrics (>=2.15.0,<2.16.0)", "types-aiobotocore-sagemaker-runtime (>=2.15.0,<2.16.0)", "types-aiobotocore-savingsplans (>=2.15.0,<2.16.0)", "types-aiobotocore-scheduler (>=2.15.0,<2.16.0)", "types-aiobotocore-schemas (>=2.15.0,<2.16.0)", "types-aiobotocore-sdb (>=2.15.0,<2.16.0)", "types-aiobotocore-secretsmanager (>=2.15.0,<2.16.0)", "types-aiobotocore-securityhub (>=2.15.0,<2.16.0)", "types-aiobotocore-securitylake (>=2.15.0,<2.16.0)", "types-aiobotocore-serverlessrepo (>=2.15.0,<2.16.0)", "types-aiobotocore-service-quotas (>=2.15.0,<2.16.0)", "types-aiobotocore-servicecatalog (>=2.15.0,<2.16.0)", "types-aiobotocore-servicecatalog-appregistry (>=2.15.0,<2.16.0)", "types-aiobotocore-servicediscovery (>=2.15.0,<2.16.0)", "types-aiobotocore-ses (>=2.15.0,<2.16.0)", "types-aiobotocore-sesv2 (>=2.15.0,<2.16.0)", "types-aiobotocore-shield (>=2.15.0,<2.16.0)", "types-aiobotocore-signer (>=2.15.0,<2.16.0)", "types-aiobotocore-simspaceweaver (>=2.15.0,<2.16.0)", "types-aiobotocore-sms (>=2.15.0,<2.16.0)", "types-aiobotocore-sms-voice (>=2.15.0,<2.16.0)", "types-aiobotocore-snow-device-management (>=2.15.0,<2.16.0)", "types-aiobotocore-snowball (>=2.15.0,<2.16.0)", "types-aiobotocore-sns (>=2.15.0,<2.16.0)", "types-aiobotocore-sqs (>=2.15.0,<2.16.0)", "types-aiobotocore-ssm (>=2.15.0,<2.16.0)", "types-aiobotocore-ssm-contacts (>=2.15.0,<2.16.0)", "types-aiobotocore-ssm-incidents (>=2.15.0,<2.16.0)", "types-aiobotocore-ssm-quicksetup (>=2.15.0,<2.16.0)", "types-aiobotocore-ssm-sap (>=2.15.0,<2.16.0)", "types-aiobotocore-sso (>=2.15.0,<2.16.0)", "types-aiobotocore-sso-admin (>=2.15.0,<2.16.0)", "types-aiobotocore-sso-oidc (>=2.15.0,<2.16.0)", "types-aiobotocore-stepfunctions (>=2.15.0,<2.16.0)", "types-aiobotocore-storagegateway (>=2.15.0,<2.16.0)", "types-aiobotocore-sts (>=2.15.0,<2.16.0)", "types-aiobotocore-supplychain (>=2.15.0,<2.16.0)", "types-aiobotocore-support (>=2.15.0,<2.16.0)", "types-aiobotocore-support-app (>=2.15.0,<2.16.0)", "types-aiobotocore-swf (>=2.15.0,<2.16.0)", "types-aiobotocore-synthetics (>=2.15.0,<2.16.0)", "types-aiobotocore-taxsettings (>=2.15.0,<2.16.0)", "types-aiobotocore-textract (>=2.15.0,<2.16.0)", "types-aiobotocore-timestream-influxdb (>=2.15.0,<2.16.0)", "types-aiobotocore-timestream-query (>=2.15.0,<2.16.0)", "types-aiobotocore-timestream-write (>=2.15.0,<2.16.0)", "types-aiobotocore-tnb (>=2.15.0,<2.16.0)", "types-aiobotocore-transcribe (>=2.15.0,<2.16.0)", "types-aiobotocore-transfer (>=2.15.0,<2.16.0)", "types-aiobotocore-translate (>=2.15.0,<2.16.0)", "types-aiobotocore-trustedadvisor (>=2.15.0,<2.16.0)", "types-aiobotocore-verifiedpermissions (>=2.15.0,<2.16.0)", "types-aiobotocore-voice-id (>=2.15.0,<2.16.0)", "types-aiobotocore-vpc-lattice (>=2.15.0,<2.16.0)", "types-aiobotocore-waf (>=2.15.0,<2.16.0)", "types-aiobotocore-waf-regional (>=2.15.0,<2.16.0)", "types-aiobotocore-wafv2 (>=2.15.0,<2.16.0)", "types-aiobotocore-wellarchitected (>=2.15.0,<2.16.0)", "types-aiobotocore-wisdom (>=2.15.0,<2.16.0)", "types-aiobotocore-workdocs (>=2.15.0,<2.16.0)", "types-aiobotocore-worklink (>=2.15.0,<2.16.0)", "types-aiobotocore-workmail (>=2.15.0,<2.16.0)", "types-aiobotocore-workmailmessageflow (>=2.15.0,<2.16.0)", "types-aiobotocore-workspaces (>=2.15.0,<2.16.0)", "types-aiobotocore-workspaces-thin-client (>=2.15.0,<2.16.0)", "types-aiobotocore-workspaces-web (>=2.15.0,<2.16.0)", "types-aiobotocore-xray (>=2.15.0,<2.16.0)"]
+aiobotocore = ["aiobotocore (==2.15.1)", "botocore (==1.35.23)"]
+all = ["types-aiobotocore-accessanalyzer (>=2.15.0,<2.16.0)", "types-aiobotocore-account (>=2.15.0,<2.16.0)", "types-aiobotocore-acm (>=2.15.0,<2.16.0)", "types-aiobotocore-acm-pca (>=2.15.0,<2.16.0)", "types-aiobotocore-amp (>=2.15.0,<2.16.0)", "types-aiobotocore-amplify (>=2.15.0,<2.16.0)", "types-aiobotocore-amplifybackend (>=2.15.0,<2.16.0)", "types-aiobotocore-amplifyuibuilder (>=2.15.0,<2.16.0)", "types-aiobotocore-apigateway (>=2.15.0,<2.16.0)", "types-aiobotocore-apigatewaymanagementapi (>=2.15.0,<2.16.0)", "types-aiobotocore-apigatewayv2 (>=2.15.0,<2.16.0)", "types-aiobotocore-appconfig (>=2.15.0,<2.16.0)", "types-aiobotocore-appconfigdata (>=2.15.0,<2.16.0)", "types-aiobotocore-appfabric (>=2.15.0,<2.16.0)", "types-aiobotocore-appflow (>=2.15.0,<2.16.0)", "types-aiobotocore-appintegrations (>=2.15.0,<2.16.0)", "types-aiobotocore-application-autoscaling (>=2.15.0,<2.16.0)", "types-aiobotocore-application-insights (>=2.15.0,<2.16.0)", "types-aiobotocore-application-signals (>=2.15.0,<2.16.0)", "types-aiobotocore-applicationcostprofiler (>=2.15.0,<2.16.0)", "types-aiobotocore-appmesh (>=2.15.0,<2.16.0)", "types-aiobotocore-apprunner (>=2.15.0,<2.16.0)", "types-aiobotocore-appstream (>=2.15.0,<2.16.0)", "types-aiobotocore-appsync (>=2.15.0,<2.16.0)", "types-aiobotocore-apptest (>=2.15.0,<2.16.0)", "types-aiobotocore-arc-zonal-shift (>=2.15.0,<2.16.0)", "types-aiobotocore-artifact (>=2.15.0,<2.16.0)", "types-aiobotocore-athena (>=2.15.0,<2.16.0)", "types-aiobotocore-auditmanager (>=2.15.0,<2.16.0)", "types-aiobotocore-autoscaling (>=2.15.0,<2.16.0)", "types-aiobotocore-autoscaling-plans (>=2.15.0,<2.16.0)", "types-aiobotocore-b2bi (>=2.15.0,<2.16.0)", "types-aiobotocore-backup (>=2.15.0,<2.16.0)", "types-aiobotocore-backup-gateway (>=2.15.0,<2.16.0)", "types-aiobotocore-batch (>=2.15.0,<2.16.0)", "types-aiobotocore-bcm-data-exports (>=2.15.0,<2.16.0)", "types-aiobotocore-bedrock (>=2.15.0,<2.16.0)", "types-aiobotocore-bedrock-agent (>=2.15.0,<2.16.0)", "types-aiobotocore-bedrock-agent-runtime (>=2.15.0,<2.16.0)", "types-aiobotocore-bedrock-runtime (>=2.15.0,<2.16.0)", "types-aiobotocore-billingconductor (>=2.15.0,<2.16.0)", "types-aiobotocore-braket (>=2.15.0,<2.16.0)", "types-aiobotocore-budgets (>=2.15.0,<2.16.0)", "types-aiobotocore-ce (>=2.15.0,<2.16.0)", "types-aiobotocore-chatbot (>=2.15.0,<2.16.0)", "types-aiobotocore-chime (>=2.15.0,<2.16.0)", "types-aiobotocore-chime-sdk-identity (>=2.15.0,<2.16.0)", "types-aiobotocore-chime-sdk-media-pipelines (>=2.15.0,<2.16.0)", "types-aiobotocore-chime-sdk-meetings (>=2.15.0,<2.16.0)", "types-aiobotocore-chime-sdk-messaging (>=2.15.0,<2.16.0)", "types-aiobotocore-chime-sdk-voice (>=2.15.0,<2.16.0)", "types-aiobotocore-cleanrooms (>=2.15.0,<2.16.0)", "types-aiobotocore-cleanroomsml (>=2.15.0,<2.16.0)", "types-aiobotocore-cloud9 (>=2.15.0,<2.16.0)", "types-aiobotocore-cloudcontrol (>=2.15.0,<2.16.0)", "types-aiobotocore-clouddirectory (>=2.15.0,<2.16.0)", "types-aiobotocore-cloudformation (>=2.15.0,<2.16.0)", "types-aiobotocore-cloudfront (>=2.15.0,<2.16.0)", "types-aiobotocore-cloudfront-keyvaluestore (>=2.15.0,<2.16.0)", "types-aiobotocore-cloudhsm (>=2.15.0,<2.16.0)", "types-aiobotocore-cloudhsmv2 (>=2.15.0,<2.16.0)", "types-aiobotocore-cloudsearch (>=2.15.0,<2.16.0)", "types-aiobotocore-cloudsearchdomain (>=2.15.0,<2.16.0)", "types-aiobotocore-cloudtrail (>=2.15.0,<2.16.0)", "types-aiobotocore-cloudtrail-data (>=2.15.0,<2.16.0)", "types-aiobotocore-cloudwatch (>=2.15.0,<2.16.0)", "types-aiobotocore-codeartifact (>=2.15.0,<2.16.0)", "types-aiobotocore-codebuild (>=2.15.0,<2.16.0)", "types-aiobotocore-codecatalyst (>=2.15.0,<2.16.0)", "types-aiobotocore-codecommit (>=2.15.0,<2.16.0)", "types-aiobotocore-codeconnections (>=2.15.0,<2.16.0)", "types-aiobotocore-codedeploy (>=2.15.0,<2.16.0)", "types-aiobotocore-codeguru-reviewer (>=2.15.0,<2.16.0)", "types-aiobotocore-codeguru-security (>=2.15.0,<2.16.0)", "types-aiobotocore-codeguruprofiler (>=2.15.0,<2.16.0)", "types-aiobotocore-codepipeline (>=2.15.0,<2.16.0)", "types-aiobotocore-codestar-connections (>=2.15.0,<2.16.0)", "types-aiobotocore-codestar-notifications (>=2.15.0,<2.16.0)", "types-aiobotocore-cognito-identity (>=2.15.0,<2.16.0)", "types-aiobotocore-cognito-idp (>=2.15.0,<2.16.0)", "types-aiobotocore-cognito-sync (>=2.15.0,<2.16.0)", "types-aiobotocore-comprehend (>=2.15.0,<2.16.0)", "types-aiobotocore-comprehendmedical (>=2.15.0,<2.16.0)", "types-aiobotocore-compute-optimizer (>=2.15.0,<2.16.0)", "types-aiobotocore-config (>=2.15.0,<2.16.0)", "types-aiobotocore-connect (>=2.15.0,<2.16.0)", "types-aiobotocore-connect-contact-lens (>=2.15.0,<2.16.0)", "types-aiobotocore-connectcampaigns (>=2.15.0,<2.16.0)", "types-aiobotocore-connectcases (>=2.15.0,<2.16.0)", "types-aiobotocore-connectparticipant (>=2.15.0,<2.16.0)", "types-aiobotocore-controlcatalog (>=2.15.0,<2.16.0)", "types-aiobotocore-controltower (>=2.15.0,<2.16.0)", "types-aiobotocore-cost-optimization-hub (>=2.15.0,<2.16.0)", "types-aiobotocore-cur (>=2.15.0,<2.16.0)", "types-aiobotocore-customer-profiles (>=2.15.0,<2.16.0)", "types-aiobotocore-databrew (>=2.15.0,<2.16.0)", "types-aiobotocore-dataexchange (>=2.15.0,<2.16.0)", "types-aiobotocore-datapipeline (>=2.15.0,<2.16.0)", "types-aiobotocore-datasync (>=2.15.0,<2.16.0)", "types-aiobotocore-datazone (>=2.15.0,<2.16.0)", "types-aiobotocore-dax (>=2.15.0,<2.16.0)", "types-aiobotocore-deadline (>=2.15.0,<2.16.0)", "types-aiobotocore-detective (>=2.15.0,<2.16.0)", "types-aiobotocore-devicefarm (>=2.15.0,<2.16.0)", "types-aiobotocore-devops-guru (>=2.15.0,<2.16.0)", "types-aiobotocore-directconnect (>=2.15.0,<2.16.0)", "types-aiobotocore-discovery (>=2.15.0,<2.16.0)", "types-aiobotocore-dlm (>=2.15.0,<2.16.0)", "types-aiobotocore-dms (>=2.15.0,<2.16.0)", "types-aiobotocore-docdb (>=2.15.0,<2.16.0)", "types-aiobotocore-docdb-elastic (>=2.15.0,<2.16.0)", "types-aiobotocore-drs (>=2.15.0,<2.16.0)", "types-aiobotocore-ds (>=2.15.0,<2.16.0)", "types-aiobotocore-ds-data (>=2.15.0,<2.16.0)", "types-aiobotocore-dynamodb (>=2.15.0,<2.16.0)", "types-aiobotocore-dynamodbstreams (>=2.15.0,<2.16.0)", "types-aiobotocore-ebs (>=2.15.0,<2.16.0)", "types-aiobotocore-ec2 (>=2.15.0,<2.16.0)", "types-aiobotocore-ec2-instance-connect (>=2.15.0,<2.16.0)", "types-aiobotocore-ecr (>=2.15.0,<2.16.0)", "types-aiobotocore-ecr-public (>=2.15.0,<2.16.0)", "types-aiobotocore-ecs (>=2.15.0,<2.16.0)", "types-aiobotocore-efs (>=2.15.0,<2.16.0)", "types-aiobotocore-eks (>=2.15.0,<2.16.0)", "types-aiobotocore-eks-auth (>=2.15.0,<2.16.0)", "types-aiobotocore-elastic-inference (>=2.15.0,<2.16.0)", "types-aiobotocore-elasticache (>=2.15.0,<2.16.0)", "types-aiobotocore-elasticbeanstalk (>=2.15.0,<2.16.0)", "types-aiobotocore-elastictranscoder (>=2.15.0,<2.16.0)", "types-aiobotocore-elb (>=2.15.0,<2.16.0)", "types-aiobotocore-elbv2 (>=2.15.0,<2.16.0)", "types-aiobotocore-emr (>=2.15.0,<2.16.0)", "types-aiobotocore-emr-containers (>=2.15.0,<2.16.0)", "types-aiobotocore-emr-serverless (>=2.15.0,<2.16.0)", "types-aiobotocore-entityresolution (>=2.15.0,<2.16.0)", "types-aiobotocore-es (>=2.15.0,<2.16.0)", "types-aiobotocore-events (>=2.15.0,<2.16.0)", "types-aiobotocore-evidently (>=2.15.0,<2.16.0)", "types-aiobotocore-finspace (>=2.15.0,<2.16.0)", "types-aiobotocore-finspace-data (>=2.15.0,<2.16.0)", "types-aiobotocore-firehose (>=2.15.0,<2.16.0)", "types-aiobotocore-fis (>=2.15.0,<2.16.0)", "types-aiobotocore-fms (>=2.15.0,<2.16.0)", "types-aiobotocore-forecast (>=2.15.0,<2.16.0)", "types-aiobotocore-forecastquery (>=2.15.0,<2.16.0)", "types-aiobotocore-frauddetector (>=2.15.0,<2.16.0)", "types-aiobotocore-freetier (>=2.15.0,<2.16.0)", "types-aiobotocore-fsx (>=2.15.0,<2.16.0)", "types-aiobotocore-gamelift (>=2.15.0,<2.16.0)", "types-aiobotocore-glacier (>=2.15.0,<2.16.0)", "types-aiobotocore-globalaccelerator (>=2.15.0,<2.16.0)", "types-aiobotocore-glue (>=2.15.0,<2.16.0)", "types-aiobotocore-grafana (>=2.15.0,<2.16.0)", "types-aiobotocore-greengrass (>=2.15.0,<2.16.0)", "types-aiobotocore-greengrassv2 (>=2.15.0,<2.16.0)", "types-aiobotocore-groundstation (>=2.15.0,<2.16.0)", "types-aiobotocore-guardduty (>=2.15.0,<2.16.0)", "types-aiobotocore-health (>=2.15.0,<2.16.0)", "types-aiobotocore-healthlake (>=2.15.0,<2.16.0)", "types-aiobotocore-iam (>=2.15.0,<2.16.0)", "types-aiobotocore-identitystore (>=2.15.0,<2.16.0)", "types-aiobotocore-imagebuilder (>=2.15.0,<2.16.0)", "types-aiobotocore-importexport (>=2.15.0,<2.16.0)", "types-aiobotocore-inspector (>=2.15.0,<2.16.0)", "types-aiobotocore-inspector-scan (>=2.15.0,<2.16.0)", "types-aiobotocore-inspector2 (>=2.15.0,<2.16.0)", "types-aiobotocore-internetmonitor (>=2.15.0,<2.16.0)", "types-aiobotocore-iot (>=2.15.0,<2.16.0)", "types-aiobotocore-iot-data (>=2.15.0,<2.16.0)", "types-aiobotocore-iot-jobs-data (>=2.15.0,<2.16.0)", "types-aiobotocore-iot1click-devices (>=2.15.0,<2.16.0)", "types-aiobotocore-iot1click-projects (>=2.15.0,<2.16.0)", "types-aiobotocore-iotanalytics (>=2.15.0,<2.16.0)", "types-aiobotocore-iotdeviceadvisor (>=2.15.0,<2.16.0)", "types-aiobotocore-iotevents (>=2.15.0,<2.16.0)", "types-aiobotocore-iotevents-data (>=2.15.0,<2.16.0)", "types-aiobotocore-iotfleethub (>=2.15.0,<2.16.0)", "types-aiobotocore-iotfleetwise (>=2.15.0,<2.16.0)", "types-aiobotocore-iotsecuretunneling (>=2.15.0,<2.16.0)", "types-aiobotocore-iotsitewise (>=2.15.0,<2.16.0)", "types-aiobotocore-iotthingsgraph (>=2.15.0,<2.16.0)", "types-aiobotocore-iottwinmaker (>=2.15.0,<2.16.0)", "types-aiobotocore-iotwireless (>=2.15.0,<2.16.0)", "types-aiobotocore-ivs (>=2.15.0,<2.16.0)", "types-aiobotocore-ivs-realtime (>=2.15.0,<2.16.0)", "types-aiobotocore-ivschat (>=2.15.0,<2.16.0)", "types-aiobotocore-kafka (>=2.15.0,<2.16.0)", "types-aiobotocore-kafkaconnect (>=2.15.0,<2.16.0)", "types-aiobotocore-kendra (>=2.15.0,<2.16.0)", "types-aiobotocore-kendra-ranking (>=2.15.0,<2.16.0)", "types-aiobotocore-keyspaces (>=2.15.0,<2.16.0)", "types-aiobotocore-kinesis (>=2.15.0,<2.16.0)", "types-aiobotocore-kinesis-video-archived-media (>=2.15.0,<2.16.0)", "types-aiobotocore-kinesis-video-media (>=2.15.0,<2.16.0)", "types-aiobotocore-kinesis-video-signaling (>=2.15.0,<2.16.0)", "types-aiobotocore-kinesis-video-webrtc-storage (>=2.15.0,<2.16.0)", "types-aiobotocore-kinesisanalytics (>=2.15.0,<2.16.0)", "types-aiobotocore-kinesisanalyticsv2 (>=2.15.0,<2.16.0)", "types-aiobotocore-kinesisvideo (>=2.15.0,<2.16.0)", "types-aiobotocore-kms (>=2.15.0,<2.16.0)", "types-aiobotocore-lakeformation (>=2.15.0,<2.16.0)", "types-aiobotocore-lambda (>=2.15.0,<2.16.0)", "types-aiobotocore-launch-wizard (>=2.15.0,<2.16.0)", "types-aiobotocore-lex-models (>=2.15.0,<2.16.0)", "types-aiobotocore-lex-runtime (>=2.15.0,<2.16.0)", "types-aiobotocore-lexv2-models (>=2.15.0,<2.16.0)", "types-aiobotocore-lexv2-runtime (>=2.15.0,<2.16.0)", "types-aiobotocore-license-manager (>=2.15.0,<2.16.0)", "types-aiobotocore-license-manager-linux-subscriptions (>=2.15.0,<2.16.0)", "types-aiobotocore-license-manager-user-subscriptions (>=2.15.0,<2.16.0)", "types-aiobotocore-lightsail (>=2.15.0,<2.16.0)", "types-aiobotocore-location (>=2.15.0,<2.16.0)", "types-aiobotocore-logs (>=2.15.0,<2.16.0)", "types-aiobotocore-lookoutequipment (>=2.15.0,<2.16.0)", "types-aiobotocore-lookoutmetrics (>=2.15.0,<2.16.0)", "types-aiobotocore-lookoutvision (>=2.15.0,<2.16.0)", "types-aiobotocore-m2 (>=2.15.0,<2.16.0)", "types-aiobotocore-machinelearning (>=2.15.0,<2.16.0)", "types-aiobotocore-macie2 (>=2.15.0,<2.16.0)", "types-aiobotocore-mailmanager (>=2.15.0,<2.16.0)", "types-aiobotocore-managedblockchain (>=2.15.0,<2.16.0)", "types-aiobotocore-managedblockchain-query (>=2.15.0,<2.16.0)", "types-aiobotocore-marketplace-agreement (>=2.15.0,<2.16.0)", "types-aiobotocore-marketplace-catalog (>=2.15.0,<2.16.0)", "types-aiobotocore-marketplace-deployment (>=2.15.0,<2.16.0)", "types-aiobotocore-marketplace-entitlement (>=2.15.0,<2.16.0)", "types-aiobotocore-marketplacecommerceanalytics (>=2.15.0,<2.16.0)", "types-aiobotocore-mediaconnect (>=2.15.0,<2.16.0)", "types-aiobotocore-mediaconvert (>=2.15.0,<2.16.0)", "types-aiobotocore-medialive (>=2.15.0,<2.16.0)", "types-aiobotocore-mediapackage (>=2.15.0,<2.16.0)", "types-aiobotocore-mediapackage-vod (>=2.15.0,<2.16.0)", "types-aiobotocore-mediapackagev2 (>=2.15.0,<2.16.0)", "types-aiobotocore-mediastore (>=2.15.0,<2.16.0)", "types-aiobotocore-mediastore-data (>=2.15.0,<2.16.0)", "types-aiobotocore-mediatailor (>=2.15.0,<2.16.0)", "types-aiobotocore-medical-imaging (>=2.15.0,<2.16.0)", "types-aiobotocore-memorydb (>=2.15.0,<2.16.0)", "types-aiobotocore-meteringmarketplace (>=2.15.0,<2.16.0)", "types-aiobotocore-mgh (>=2.15.0,<2.16.0)", "types-aiobotocore-mgn (>=2.15.0,<2.16.0)", "types-aiobotocore-migration-hub-refactor-spaces (>=2.15.0,<2.16.0)", "types-aiobotocore-migrationhub-config (>=2.15.0,<2.16.0)", "types-aiobotocore-migrationhuborchestrator (>=2.15.0,<2.16.0)", "types-aiobotocore-migrationhubstrategy (>=2.15.0,<2.16.0)", "types-aiobotocore-mq (>=2.15.0,<2.16.0)", "types-aiobotocore-mturk (>=2.15.0,<2.16.0)", "types-aiobotocore-mwaa (>=2.15.0,<2.16.0)", "types-aiobotocore-neptune (>=2.15.0,<2.16.0)", "types-aiobotocore-neptune-graph (>=2.15.0,<2.16.0)", "types-aiobotocore-neptunedata (>=2.15.0,<2.16.0)", "types-aiobotocore-network-firewall (>=2.15.0,<2.16.0)", "types-aiobotocore-networkmanager (>=2.15.0,<2.16.0)", "types-aiobotocore-networkmonitor (>=2.15.0,<2.16.0)", "types-aiobotocore-nimble (>=2.15.0,<2.16.0)", "types-aiobotocore-oam (>=2.15.0,<2.16.0)", "types-aiobotocore-omics (>=2.15.0,<2.16.0)", "types-aiobotocore-opensearch (>=2.15.0,<2.16.0)", "types-aiobotocore-opensearchserverless (>=2.15.0,<2.16.0)", "types-aiobotocore-opsworks (>=2.15.0,<2.16.0)", "types-aiobotocore-opsworkscm (>=2.15.0,<2.16.0)", "types-aiobotocore-organizations (>=2.15.0,<2.16.0)", "types-aiobotocore-osis (>=2.15.0,<2.16.0)", "types-aiobotocore-outposts (>=2.15.0,<2.16.0)", "types-aiobotocore-panorama (>=2.15.0,<2.16.0)", "types-aiobotocore-payment-cryptography (>=2.15.0,<2.16.0)", "types-aiobotocore-payment-cryptography-data (>=2.15.0,<2.16.0)", "types-aiobotocore-pca-connector-ad (>=2.15.0,<2.16.0)", "types-aiobotocore-pca-connector-scep (>=2.15.0,<2.16.0)", "types-aiobotocore-pcs (>=2.15.0,<2.16.0)", "types-aiobotocore-personalize (>=2.15.0,<2.16.0)", "types-aiobotocore-personalize-events (>=2.15.0,<2.16.0)", "types-aiobotocore-personalize-runtime (>=2.15.0,<2.16.0)", "types-aiobotocore-pi (>=2.15.0,<2.16.0)", "types-aiobotocore-pinpoint (>=2.15.0,<2.16.0)", "types-aiobotocore-pinpoint-email (>=2.15.0,<2.16.0)", "types-aiobotocore-pinpoint-sms-voice (>=2.15.0,<2.16.0)", "types-aiobotocore-pinpoint-sms-voice-v2 (>=2.15.0,<2.16.0)", "types-aiobotocore-pipes (>=2.15.0,<2.16.0)", "types-aiobotocore-polly (>=2.15.0,<2.16.0)", "types-aiobotocore-pricing (>=2.15.0,<2.16.0)", "types-aiobotocore-privatenetworks (>=2.15.0,<2.16.0)", "types-aiobotocore-proton (>=2.15.0,<2.16.0)", "types-aiobotocore-qapps (>=2.15.0,<2.16.0)", "types-aiobotocore-qbusiness (>=2.15.0,<2.16.0)", "types-aiobotocore-qconnect (>=2.15.0,<2.16.0)", "types-aiobotocore-qldb (>=2.15.0,<2.16.0)", "types-aiobotocore-qldb-session (>=2.15.0,<2.16.0)", "types-aiobotocore-quicksight (>=2.15.0,<2.16.0)", "types-aiobotocore-ram (>=2.15.0,<2.16.0)", "types-aiobotocore-rbin (>=2.15.0,<2.16.0)", "types-aiobotocore-rds (>=2.15.0,<2.16.0)", "types-aiobotocore-rds-data (>=2.15.0,<2.16.0)", "types-aiobotocore-redshift (>=2.15.0,<2.16.0)", "types-aiobotocore-redshift-data (>=2.15.0,<2.16.0)", "types-aiobotocore-redshift-serverless (>=2.15.0,<2.16.0)", "types-aiobotocore-rekognition (>=2.15.0,<2.16.0)", "types-aiobotocore-repostspace (>=2.15.0,<2.16.0)", "types-aiobotocore-resiliencehub (>=2.15.0,<2.16.0)", "types-aiobotocore-resource-explorer-2 (>=2.15.0,<2.16.0)", "types-aiobotocore-resource-groups (>=2.15.0,<2.16.0)", "types-aiobotocore-resourcegroupstaggingapi (>=2.15.0,<2.16.0)", "types-aiobotocore-robomaker (>=2.15.0,<2.16.0)", "types-aiobotocore-rolesanywhere (>=2.15.0,<2.16.0)", "types-aiobotocore-route53 (>=2.15.0,<2.16.0)", "types-aiobotocore-route53-recovery-cluster (>=2.15.0,<2.16.0)", "types-aiobotocore-route53-recovery-control-config (>=2.15.0,<2.16.0)", "types-aiobotocore-route53-recovery-readiness (>=2.15.0,<2.16.0)", "types-aiobotocore-route53domains (>=2.15.0,<2.16.0)", "types-aiobotocore-route53profiles (>=2.15.0,<2.16.0)", "types-aiobotocore-route53resolver (>=2.15.0,<2.16.0)", "types-aiobotocore-rum (>=2.15.0,<2.16.0)", "types-aiobotocore-s3 (>=2.15.0,<2.16.0)", "types-aiobotocore-s3control (>=2.15.0,<2.16.0)", "types-aiobotocore-s3outposts (>=2.15.0,<2.16.0)", "types-aiobotocore-sagemaker (>=2.15.0,<2.16.0)", "types-aiobotocore-sagemaker-a2i-runtime (>=2.15.0,<2.16.0)", "types-aiobotocore-sagemaker-edge (>=2.15.0,<2.16.0)", "types-aiobotocore-sagemaker-featurestore-runtime (>=2.15.0,<2.16.0)", "types-aiobotocore-sagemaker-geospatial (>=2.15.0,<2.16.0)", "types-aiobotocore-sagemaker-metrics (>=2.15.0,<2.16.0)", "types-aiobotocore-sagemaker-runtime (>=2.15.0,<2.16.0)", "types-aiobotocore-savingsplans (>=2.15.0,<2.16.0)", "types-aiobotocore-scheduler (>=2.15.0,<2.16.0)", "types-aiobotocore-schemas (>=2.15.0,<2.16.0)", "types-aiobotocore-sdb (>=2.15.0,<2.16.0)", "types-aiobotocore-secretsmanager (>=2.15.0,<2.16.0)", "types-aiobotocore-securityhub (>=2.15.0,<2.16.0)", "types-aiobotocore-securitylake (>=2.15.0,<2.16.0)", "types-aiobotocore-serverlessrepo (>=2.15.0,<2.16.0)", "types-aiobotocore-service-quotas (>=2.15.0,<2.16.0)", "types-aiobotocore-servicecatalog (>=2.15.0,<2.16.0)", "types-aiobotocore-servicecatalog-appregistry (>=2.15.0,<2.16.0)", "types-aiobotocore-servicediscovery (>=2.15.0,<2.16.0)", "types-aiobotocore-ses (>=2.15.0,<2.16.0)", "types-aiobotocore-sesv2 (>=2.15.0,<2.16.0)", "types-aiobotocore-shield (>=2.15.0,<2.16.0)", "types-aiobotocore-signer (>=2.15.0,<2.16.0)", "types-aiobotocore-simspaceweaver (>=2.15.0,<2.16.0)", "types-aiobotocore-sms (>=2.15.0,<2.16.0)", "types-aiobotocore-sms-voice (>=2.15.0,<2.16.0)", "types-aiobotocore-snow-device-management (>=2.15.0,<2.16.0)", "types-aiobotocore-snowball (>=2.15.0,<2.16.0)", "types-aiobotocore-sns (>=2.15.0,<2.16.0)", "types-aiobotocore-sqs (>=2.15.0,<2.16.0)", "types-aiobotocore-ssm (>=2.15.0,<2.16.0)", "types-aiobotocore-ssm-contacts (>=2.15.0,<2.16.0)", "types-aiobotocore-ssm-incidents (>=2.15.0,<2.16.0)", "types-aiobotocore-ssm-quicksetup (>=2.15.0,<2.16.0)", "types-aiobotocore-ssm-sap (>=2.15.0,<2.16.0)", "types-aiobotocore-sso (>=2.15.0,<2.16.0)", "types-aiobotocore-sso-admin (>=2.15.0,<2.16.0)", "types-aiobotocore-sso-oidc (>=2.15.0,<2.16.0)", "types-aiobotocore-stepfunctions (>=2.15.0,<2.16.0)", "types-aiobotocore-storagegateway (>=2.15.0,<2.16.0)", "types-aiobotocore-sts (>=2.15.0,<2.16.0)", "types-aiobotocore-supplychain (>=2.15.0,<2.16.0)", "types-aiobotocore-support (>=2.15.0,<2.16.0)", "types-aiobotocore-support-app (>=2.15.0,<2.16.0)", "types-aiobotocore-swf (>=2.15.0,<2.16.0)", "types-aiobotocore-synthetics (>=2.15.0,<2.16.0)", "types-aiobotocore-taxsettings (>=2.15.0,<2.16.0)", "types-aiobotocore-textract (>=2.15.0,<2.16.0)", "types-aiobotocore-timestream-influxdb (>=2.15.0,<2.16.0)", "types-aiobotocore-timestream-query (>=2.15.0,<2.16.0)", "types-aiobotocore-timestream-write (>=2.15.0,<2.16.0)", "types-aiobotocore-tnb (>=2.15.0,<2.16.0)", "types-aiobotocore-transcribe (>=2.15.0,<2.16.0)", "types-aiobotocore-transfer (>=2.15.0,<2.16.0)", "types-aiobotocore-translate (>=2.15.0,<2.16.0)", "types-aiobotocore-trustedadvisor (>=2.15.0,<2.16.0)", "types-aiobotocore-verifiedpermissions (>=2.15.0,<2.16.0)", "types-aiobotocore-voice-id (>=2.15.0,<2.16.0)", "types-aiobotocore-vpc-lattice (>=2.15.0,<2.16.0)", "types-aiobotocore-waf (>=2.15.0,<2.16.0)", "types-aiobotocore-waf-regional (>=2.15.0,<2.16.0)", "types-aiobotocore-wafv2 (>=2.15.0,<2.16.0)", "types-aiobotocore-wellarchitected (>=2.15.0,<2.16.0)", "types-aiobotocore-wisdom (>=2.15.0,<2.16.0)", "types-aiobotocore-workdocs (>=2.15.0,<2.16.0)", "types-aiobotocore-worklink (>=2.15.0,<2.16.0)", "types-aiobotocore-workmail (>=2.15.0,<2.16.0)", "types-aiobotocore-workmailmessageflow (>=2.15.0,<2.16.0)", "types-aiobotocore-workspaces (>=2.15.0,<2.16.0)", "types-aiobotocore-workspaces-thin-client (>=2.15.0,<2.16.0)", "types-aiobotocore-workspaces-web (>=2.15.0,<2.16.0)", "types-aiobotocore-xray (>=2.15.0,<2.16.0)"]
 amp = ["types-aiobotocore-amp (>=2.15.0,<2.16.0)"]
 amplify = ["types-aiobotocore-amplify (>=2.15.0,<2.16.0)"]
 amplifybackend = ["types-aiobotocore-amplifybackend (>=2.15.0,<2.16.0)"]
@@ -2275,6 +2386,7 @@ docdb = ["types-aiobotocore-docdb (>=2.15.0,<2.16.0)"]
 docdb-elastic = ["types-aiobotocore-docdb-elastic (>=2.15.0,<2.16.0)"]
 drs = ["types-aiobotocore-drs (>=2.15.0,<2.16.0)"]
 ds = ["types-aiobotocore-ds (>=2.15.0,<2.16.0)"]
+ds-data = ["types-aiobotocore-ds-data (>=2.15.0,<2.16.0)"]
 dynamodb = ["types-aiobotocore-dynamodb (>=2.15.0,<2.16.0)"]
 dynamodbstreams = ["types-aiobotocore-dynamodbstreams (>=2.15.0,<2.16.0)"]
 ebs = ["types-aiobotocore-ebs (>=2.15.0,<2.16.0)"]
@@ -2310,6 +2422,7 @@ forecastquery = ["types-aiobotocore-forecastquery (>=2.15.0,<2.16.0)"]
 frauddetector = ["types-aiobotocore-frauddetector (>=2.15.0,<2.16.0)"]
 freetier = ["types-aiobotocore-freetier (>=2.15.0,<2.16.0)"]
 fsx = ["types-aiobotocore-fsx (>=2.15.0,<2.16.0)"]
+full = ["types-aiobotocore-full"]
 gamelift = ["types-aiobotocore-gamelift (>=2.15.0,<2.16.0)"]
 glacier = ["types-aiobotocore-glacier (>=2.15.0,<2.16.0)"]
 globalaccelerator = ["types-aiobotocore-globalaccelerator (>=2.15.0,<2.16.0)"]
@@ -2552,13 +2665,13 @@ xray = ["types-aiobotocore-xray (>=2.15.0,<2.16.0)"]
 
 [[package]]
 name = "types-aiobotocore-dynamodb"
-version = "2.15.0.post1"
-description = "Type annotations for aiobotocore.DynamoDB 2.15.0 service generated with mypy-boto3-builder 8.1.1"
+version = "2.15.1"
+description = "Type annotations for aiobotocore.DynamoDB 2.15.1 service generated with mypy-boto3-builder 8.1.2"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "types_aiobotocore_dynamodb-2.15.0.post1-py3-none-any.whl", hash = "sha256:f52658e5626ed1b6fc97f60b18c0c3d1d919d84e8dfeb03bafd487dde1dda1b4"},
-    {file = "types_aiobotocore_dynamodb-2.15.0.post1.tar.gz", hash = "sha256:43ee250f274f4fc3a9ff895a3ffea6b54cbfce8eb5784296f68352a9cb2c2263"},
+    {file = "types_aiobotocore_dynamodb-2.15.1-py3-none-any.whl", hash = "sha256:55f2f4701a9d7af211acf73266f78214c8e4bb6fc4520e8ec20261e3559cd007"},
+    {file = "types_aiobotocore_dynamodb-2.15.1.tar.gz", hash = "sha256:850b761edc9ef95b9b487c3ed88cf913c220cc71b00309b260490d2346ebede5"},
 ]
 
 [package.dependencies]
@@ -2566,13 +2679,13 @@ typing-extensions = {version = ">=4.1.0", markers = "python_version < \"3.12\""}
 
 [[package]]
 name = "types-awscrt"
-version = "0.21.5"
+version = "0.22.0"
 description = "Type annotations and code completion for awscrt"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "types_awscrt-0.21.5-py3-none-any.whl", hash = "sha256:117ff2b1bb657f09d01b7e0ce3fe3fa6e039be12d30b826896182725c9ce85b1"},
-    {file = "types_awscrt-0.21.5.tar.gz", hash = "sha256:9f7f47de68799cb2bcb9e486f48d77b9f58962b92fba43cb8860da70b3c57d1b"},
+    {file = "types_awscrt-0.22.0-py3-none-any.whl", hash = "sha256:b2c196bbd3226bab42d80fae13c34548de9ddc195f5a366d79c15d18e5897aa9"},
+    {file = "types_awscrt-0.22.0.tar.gz", hash = "sha256:67a660c90bad360c339f6a79310cc17094d12472042c7ca5a41450aaf5fc9a54"},
 ]
 
 [[package]]
@@ -2643,13 +2756,13 @@ files = [
 
 [[package]]
 name = "tzdata"
-version = "2024.1"
+version = "2024.2"
 description = "Provider of IANA time zone data"
 optional = false
 python-versions = ">=2"
 files = [
-    {file = "tzdata-2024.1-py2.py3-none-any.whl", hash = "sha256:9068bc196136463f5245e51efda838afa15aaeca9903f49050dfa2679db4d252"},
-    {file = "tzdata-2024.1.tar.gz", hash = "sha256:2674120f8d891909751c38abcdfd386ac0a5a1127954fbc332af6b5ceae07efd"},
+    {file = "tzdata-2024.2-py2.py3-none-any.whl", hash = "sha256:a48093786cdcde33cad18c2555e8532f34422074448fbc874186f0abd79565cd"},
+    {file = "tzdata-2024.2.tar.gz", hash = "sha256:7d85cc416e9382e69095b7bdf4afd9e3880418a2413feec7069d533d6b4e31cc"},
 ]
 
 [[package]]
@@ -2687,13 +2800,13 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "uvicorn"
-version = "0.30.6"
+version = "0.31.0"
 description = "The lightning-fast ASGI server."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "uvicorn-0.30.6-py3-none-any.whl", hash = "sha256:65fd46fe3fda5bdc1b03b94eb634923ff18cd35b2f084813ea79d1f103f711b5"},
-    {file = "uvicorn-0.30.6.tar.gz", hash = "sha256:4b15decdda1e72be08209e860a1e10e92439ad5b97cf44cc945fcbee66fc5788"},
+    {file = "uvicorn-0.31.0-py3-none-any.whl", hash = "sha256:cac7be4dd4d891c363cd942160a7b02e69150dcbc7a36be04d5f4af4b17c8ced"},
+    {file = "uvicorn-0.31.0.tar.gz", hash = "sha256:13bc21373d103859f68fe739608e2eb054a816dea79189bc3ca08ea89a275906"},
 ]
 
 [package.dependencies]
@@ -2705,14 +2818,33 @@ typing-extensions = {version = ">=4.0", markers = "python_version < \"3.11\""}
 standard = ["colorama (>=0.4)", "httptools (>=0.5.0)", "python-dotenv (>=0.13)", "pyyaml (>=5.1)", "uvloop (>=0.14.0,!=0.15.0,!=0.15.1)", "watchfiles (>=0.13)", "websockets (>=10.4)"]
 
 [[package]]
+name = "valkey"
+version = "6.0.2"
+description = "Python client for Valkey forked from redis-py"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "valkey-6.0.2-py3-none-any.whl", hash = "sha256:dbbdd65439ee0dc5689502c54f1899504cc7268e85cb7fe8935f062178ff5805"},
+    {file = "valkey-6.0.2.tar.gz", hash = "sha256:dc2e91512b82d1da0b91ab0cdbd8c97c0c0250281728cb32f9398760df9caeae"},
+]
+
+[package.dependencies]
+async-timeout = {version = ">=4.0.3", markers = "python_version < \"3.11.3\""}
+libvalkey = {version = ">=4.0.0", optional = true, markers = "extra == \"libvalkey\""}
+
+[package.extras]
+libvalkey = ["libvalkey (>=4.0.0)"]
+ocsp = ["cryptography (>=36.0.1)", "pyopenssl (==23.2.1)", "requests (>=2.31.0)"]
+
+[[package]]
 name = "virtualenv"
-version = "20.26.5"
+version = "20.26.6"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "virtualenv-20.26.5-py3-none-any.whl", hash = "sha256:4f3ac17b81fba3ce3bd6f4ead2749a72da5929c01774948e243db9ba41df4ff6"},
-    {file = "virtualenv-20.26.5.tar.gz", hash = "sha256:ce489cac131aa58f4b25e321d6d186171f78e6cb13fafbf32a840cee67733ff4"},
+    {file = "virtualenv-20.26.6-py3-none-any.whl", hash = "sha256:7345cc5b25405607a624d8418154577459c3e0277f5466dd79c49d5e492995f2"},
+    {file = "virtualenv-20.26.6.tar.gz", hash = "sha256:280aede09a2a5c317e409a00102e7077c6432c5a38f0ef938e643805a7ad2c48"},
 ]
 
 [package.dependencies]
@@ -2805,103 +2937,103 @@ files = [
 
 [[package]]
 name = "yarl"
-version = "1.11.1"
+version = "1.13.1"
 description = "Yet another URL library"
 optional = true
 python-versions = ">=3.8"
 files = [
-    {file = "yarl-1.11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:400cd42185f92de559d29eeb529e71d80dfbd2f45c36844914a4a34297ca6f00"},
-    {file = "yarl-1.11.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:8258c86f47e080a258993eed877d579c71da7bda26af86ce6c2d2d072c11320d"},
-    {file = "yarl-1.11.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2164cd9725092761fed26f299e3f276bb4b537ca58e6ff6b252eae9631b5c96e"},
-    {file = "yarl-1.11.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08ea567c16f140af8ddc7cb58e27e9138a1386e3e6e53982abaa6f2377b38cc"},
-    {file = "yarl-1.11.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:768ecc550096b028754ea28bf90fde071c379c62c43afa574edc6f33ee5daaec"},
-    {file = "yarl-1.11.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2909fa3a7d249ef64eeb2faa04b7957e34fefb6ec9966506312349ed8a7e77bf"},
-    {file = "yarl-1.11.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:01a8697ec24f17c349c4f655763c4db70eebc56a5f82995e5e26e837c6eb0e49"},
-    {file = "yarl-1.11.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e286580b6511aac7c3268a78cdb861ec739d3e5a2a53b4809faef6b49778eaff"},
-    {file = "yarl-1.11.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:4179522dc0305c3fc9782549175c8e8849252fefeb077c92a73889ccbcd508ad"},
-    {file = "yarl-1.11.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:27fcb271a41b746bd0e2a92182df507e1c204759f460ff784ca614e12dd85145"},
-    {file = "yarl-1.11.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:f61db3b7e870914dbd9434b560075e0366771eecbe6d2b5561f5bc7485f39efd"},
-    {file = "yarl-1.11.1-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:c92261eb2ad367629dc437536463dc934030c9e7caca861cc51990fe6c565f26"},
-    {file = "yarl-1.11.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:d95b52fbef190ca87d8c42f49e314eace4fc52070f3dfa5f87a6594b0c1c6e46"},
-    {file = "yarl-1.11.1-cp310-cp310-win32.whl", hash = "sha256:489fa8bde4f1244ad6c5f6d11bb33e09cf0d1d0367edb197619c3e3fc06f3d91"},
-    {file = "yarl-1.11.1-cp310-cp310-win_amd64.whl", hash = "sha256:476e20c433b356e16e9a141449f25161e6b69984fb4cdbd7cd4bd54c17844998"},
-    {file = "yarl-1.11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:946eedc12895873891aaceb39bceb484b4977f70373e0122da483f6c38faaa68"},
-    {file = "yarl-1.11.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:21a7c12321436b066c11ec19c7e3cb9aec18884fe0d5b25d03d756a9e654edfe"},
-    {file = "yarl-1.11.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c35f493b867912f6fda721a59cc7c4766d382040bdf1ddaeeaa7fa4d072f4675"},
-    {file = "yarl-1.11.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25861303e0be76b60fddc1250ec5986c42f0a5c0c50ff57cc30b1be199c00e63"},
-    {file = "yarl-1.11.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e4b53f73077e839b3f89c992223f15b1d2ab314bdbdf502afdc7bb18e95eae27"},
-    {file = "yarl-1.11.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:327c724b01b8641a1bf1ab3b232fb638706e50f76c0b5bf16051ab65c868fac5"},
-    {file = "yarl-1.11.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4307d9a3417eea87715c9736d050c83e8c1904e9b7aada6ce61b46361b733d92"},
-    {file = "yarl-1.11.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:48a28bed68ab8fb7e380775f0029a079f08a17799cb3387a65d14ace16c12e2b"},
-    {file = "yarl-1.11.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:067b961853c8e62725ff2893226fef3d0da060656a9827f3f520fb1d19b2b68a"},
-    {file = "yarl-1.11.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8215f6f21394d1f46e222abeb06316e77ef328d628f593502d8fc2a9117bde83"},
-    {file = "yarl-1.11.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:498442e3af2a860a663baa14fbf23fb04b0dd758039c0e7c8f91cb9279799bff"},
-    {file = "yarl-1.11.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:69721b8effdb588cb055cc22f7c5105ca6fdaa5aeb3ea09021d517882c4a904c"},
-    {file = "yarl-1.11.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1e969fa4c1e0b1a391f3fcbcb9ec31e84440253325b534519be0d28f4b6b533e"},
-    {file = "yarl-1.11.1-cp311-cp311-win32.whl", hash = "sha256:7d51324a04fc4b0e097ff8a153e9276c2593106a811704025bbc1d6916f45ca6"},
-    {file = "yarl-1.11.1-cp311-cp311-win_amd64.whl", hash = "sha256:15061ce6584ece023457fb8b7a7a69ec40bf7114d781a8c4f5dcd68e28b5c53b"},
-    {file = "yarl-1.11.1-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:a4264515f9117be204935cd230fb2a052dd3792789cc94c101c535d349b3dab0"},
-    {file = "yarl-1.11.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:f41fa79114a1d2eddb5eea7b912d6160508f57440bd302ce96eaa384914cd265"},
-    {file = "yarl-1.11.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:02da8759b47d964f9173c8675710720b468aa1c1693be0c9c64abb9d8d9a4867"},
-    {file = "yarl-1.11.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9361628f28f48dcf8b2f528420d4d68102f593f9c2e592bfc842f5fb337e44fd"},
-    {file = "yarl-1.11.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b91044952da03b6f95fdba398d7993dd983b64d3c31c358a4c89e3c19b6f7aef"},
-    {file = "yarl-1.11.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:74db2ef03b442276d25951749a803ddb6e270d02dda1d1c556f6ae595a0d76a8"},
-    {file = "yarl-1.11.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e975a2211952a8a083d1b9d9ba26472981ae338e720b419eb50535de3c02870"},
-    {file = "yarl-1.11.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8aef97ba1dd2138112890ef848e17d8526fe80b21f743b4ee65947ea184f07a2"},
-    {file = "yarl-1.11.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a7915ea49b0c113641dc4d9338efa9bd66b6a9a485ffe75b9907e8573ca94b84"},
-    {file = "yarl-1.11.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:504cf0d4c5e4579a51261d6091267f9fd997ef58558c4ffa7a3e1460bd2336fa"},
-    {file = "yarl-1.11.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:3de5292f9f0ee285e6bd168b2a77b2a00d74cbcfa420ed078456d3023d2f6dff"},
-    {file = "yarl-1.11.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:a34e1e30f1774fa35d37202bbeae62423e9a79d78d0874e5556a593479fdf239"},
-    {file = "yarl-1.11.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:66b63c504d2ca43bf7221a1f72fbe981ff56ecb39004c70a94485d13e37ebf45"},
-    {file = "yarl-1.11.1-cp312-cp312-win32.whl", hash = "sha256:a28b70c9e2213de425d9cba5ab2e7f7a1c8ca23a99c4b5159bf77b9c31251447"},
-    {file = "yarl-1.11.1-cp312-cp312-win_amd64.whl", hash = "sha256:17b5a386d0d36fb828e2fb3ef08c8829c1ebf977eef88e5367d1c8c94b454639"},
-    {file = "yarl-1.11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:1fa2e7a406fbd45b61b4433e3aa254a2c3e14c4b3186f6e952d08a730807fa0c"},
-    {file = "yarl-1.11.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:750f656832d7d3cb0c76be137ee79405cc17e792f31e0a01eee390e383b2936e"},
-    {file = "yarl-1.11.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0b8486f322d8f6a38539136a22c55f94d269addb24db5cb6f61adc61eabc9d93"},
-    {file = "yarl-1.11.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3fce4da3703ee6048ad4138fe74619c50874afe98b1ad87b2698ef95bf92c96d"},
-    {file = "yarl-1.11.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8ed653638ef669e0efc6fe2acb792275cb419bf9cb5c5049399f3556995f23c7"},
-    {file = "yarl-1.11.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:18ac56c9dd70941ecad42b5a906820824ca72ff84ad6fa18db33c2537ae2e089"},
-    {file = "yarl-1.11.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:688654f8507464745ab563b041d1fb7dab5d9912ca6b06e61d1c4708366832f5"},
-    {file = "yarl-1.11.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4973eac1e2ff63cf187073cd4e1f1148dcd119314ab79b88e1b3fad74a18c9d5"},
-    {file = "yarl-1.11.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:964a428132227edff96d6f3cf261573cb0f1a60c9a764ce28cda9525f18f7786"},
-    {file = "yarl-1.11.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:6d23754b9939cbab02c63434776df1170e43b09c6a517585c7ce2b3d449b7318"},
-    {file = "yarl-1.11.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:c2dc4250fe94d8cd864d66018f8344d4af50e3758e9d725e94fecfa27588ff82"},
-    {file = "yarl-1.11.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:09696438cb43ea6f9492ef237761b043f9179f455f405279e609f2bc9100212a"},
-    {file = "yarl-1.11.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:999bfee0a5b7385a0af5ffb606393509cfde70ecca4f01c36985be6d33e336da"},
-    {file = "yarl-1.11.1-cp313-cp313-win32.whl", hash = "sha256:ce928c9c6409c79e10f39604a7e214b3cb69552952fbda8d836c052832e6a979"},
-    {file = "yarl-1.11.1-cp313-cp313-win_amd64.whl", hash = "sha256:501c503eed2bb306638ccb60c174f856cc3246c861829ff40eaa80e2f0330367"},
-    {file = "yarl-1.11.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:dae7bd0daeb33aa3e79e72877d3d51052e8b19c9025ecf0374f542ea8ec120e4"},
-    {file = "yarl-1.11.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:3ff6b1617aa39279fe18a76c8d165469c48b159931d9b48239065767ee455b2b"},
-    {file = "yarl-1.11.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:3257978c870728a52dcce8c2902bf01f6c53b65094b457bf87b2644ee6238ddc"},
-    {file = "yarl-1.11.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0f351fa31234699d6084ff98283cb1e852270fe9e250a3b3bf7804eb493bd937"},
-    {file = "yarl-1.11.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8aef1b64da41d18026632d99a06b3fefe1d08e85dd81d849fa7c96301ed22f1b"},
-    {file = "yarl-1.11.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7175a87ab8f7fbde37160a15e58e138ba3b2b0e05492d7351314a250d61b1591"},
-    {file = "yarl-1.11.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba444bdd4caa2a94456ef67a2f383710928820dd0117aae6650a4d17029fa25e"},
-    {file = "yarl-1.11.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0ea9682124fc062e3d931c6911934a678cb28453f957ddccf51f568c2f2b5e05"},
-    {file = "yarl-1.11.1-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:8418c053aeb236b20b0ab8fa6bacfc2feaaf7d4683dd96528610989c99723d5f"},
-    {file = "yarl-1.11.1-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:61a5f2c14d0a1adfdd82258f756b23a550c13ba4c86c84106be4c111a3a4e413"},
-    {file = "yarl-1.11.1-cp38-cp38-musllinux_1_2_ppc64le.whl", hash = "sha256:f3a6d90cab0bdf07df8f176eae3a07127daafcf7457b997b2bf46776da2c7eb7"},
-    {file = "yarl-1.11.1-cp38-cp38-musllinux_1_2_s390x.whl", hash = "sha256:077da604852be488c9a05a524068cdae1e972b7dc02438161c32420fb4ec5e14"},
-    {file = "yarl-1.11.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:15439f3c5c72686b6c3ff235279630d08936ace67d0fe5c8d5bbc3ef06f5a420"},
-    {file = "yarl-1.11.1-cp38-cp38-win32.whl", hash = "sha256:238a21849dd7554cb4d25a14ffbfa0ef380bb7ba201f45b144a14454a72ffa5a"},
-    {file = "yarl-1.11.1-cp38-cp38-win_amd64.whl", hash = "sha256:67459cf8cf31da0e2cbdb4b040507e535d25cfbb1604ca76396a3a66b8ba37a6"},
-    {file = "yarl-1.11.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:884eab2ce97cbaf89f264372eae58388862c33c4f551c15680dd80f53c89a269"},
-    {file = "yarl-1.11.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:8a336eaa7ee7e87cdece3cedb395c9657d227bfceb6781295cf56abcd3386a26"},
-    {file = "yarl-1.11.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:87f020d010ba80a247c4abc335fc13421037800ca20b42af5ae40e5fd75e7909"},
-    {file = "yarl-1.11.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:637c7ddb585a62d4469f843dac221f23eec3cbad31693b23abbc2c366ad41ff4"},
-    {file = "yarl-1.11.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:48dfd117ab93f0129084577a07287376cc69c08138694396f305636e229caa1a"},
-    {file = "yarl-1.11.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:75e0ae31fb5ccab6eda09ba1494e87eb226dcbd2372dae96b87800e1dcc98804"},
-    {file = "yarl-1.11.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f46f81501160c28d0c0b7333b4f7be8983dbbc161983b6fb814024d1b4952f79"},
-    {file = "yarl-1.11.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:04293941646647b3bfb1719d1d11ff1028e9c30199509a844da3c0f5919dc520"},
-    {file = "yarl-1.11.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:250e888fa62d73e721f3041e3a9abf427788a1934b426b45e1b92f62c1f68366"},
-    {file = "yarl-1.11.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:e8f63904df26d1a66aabc141bfd258bf738b9bc7bc6bdef22713b4f5ef789a4c"},
-    {file = "yarl-1.11.1-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:aac44097d838dda26526cffb63bdd8737a2dbdf5f2c68efb72ad83aec6673c7e"},
-    {file = "yarl-1.11.1-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:267b24f891e74eccbdff42241c5fb4f974de2d6271dcc7d7e0c9ae1079a560d9"},
-    {file = "yarl-1.11.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:6907daa4b9d7a688063ed098c472f96e8181733c525e03e866fb5db480a424df"},
-    {file = "yarl-1.11.1-cp39-cp39-win32.whl", hash = "sha256:14438dfc5015661f75f85bc5adad0743678eefee266ff0c9a8e32969d5d69f74"},
-    {file = "yarl-1.11.1-cp39-cp39-win_amd64.whl", hash = "sha256:94d0caaa912bfcdc702a4204cd5e2bb01eb917fc4f5ea2315aa23962549561b0"},
-    {file = "yarl-1.11.1-py3-none-any.whl", hash = "sha256:72bf26f66456baa0584eff63e44545c9f0eaed9b73cb6601b647c91f14c11f38"},
-    {file = "yarl-1.11.1.tar.gz", hash = "sha256:1bb2d9e212fb7449b8fb73bc461b51eaa17cc8430b4a87d87be7b25052d92f53"},
+    {file = "yarl-1.13.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:82e692fb325013a18a5b73a4fed5a1edaa7c58144dc67ad9ef3d604eccd451ad"},
+    {file = "yarl-1.13.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:df4e82e68f43a07735ae70a2d84c0353e58e20add20ec0af611f32cd5ba43fb4"},
+    {file = "yarl-1.13.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ec9dd328016d8d25702a24ee274932aebf6be9787ed1c28d021945d264235b3c"},
+    {file = "yarl-1.13.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5820bd4178e6a639b3ef1db8b18500a82ceab6d8b89309e121a6859f56585b05"},
+    {file = "yarl-1.13.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:86c438ce920e089c8c2388c7dcc8ab30dfe13c09b8af3d306bcabb46a053d6f7"},
+    {file = "yarl-1.13.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3de86547c820e4f4da4606d1c8ab5765dd633189791f15247706a2eeabc783ae"},
+    {file = "yarl-1.13.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8ca53632007c69ddcdefe1e8cbc3920dd88825e618153795b57e6ebcc92e752a"},
+    {file = "yarl-1.13.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d4ee1d240b84e2f213565f0ec08caef27a0e657d4c42859809155cf3a29d1735"},
+    {file = "yarl-1.13.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:c49f3e379177f4477f929097f7ed4b0622a586b0aa40c07ac8c0f8e40659a1ac"},
+    {file = "yarl-1.13.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:5c5e32fef09ce101fe14acd0f498232b5710effe13abac14cd95de9c274e689e"},
+    {file = "yarl-1.13.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:ab9524e45ee809a083338a749af3b53cc7efec458c3ad084361c1dbf7aaf82a2"},
+    {file = "yarl-1.13.1-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:b1481c048fe787f65e34cb06f7d6824376d5d99f1231eae4778bbe5c3831076d"},
+    {file = "yarl-1.13.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:31497aefd68036d8e31bfbacef915826ca2e741dbb97a8d6c7eac66deda3b606"},
+    {file = "yarl-1.13.1-cp310-cp310-win32.whl", hash = "sha256:1fa56f34b2236f5192cb5fceba7bbb09620e5337e0b6dfe2ea0ddbd19dd5b154"},
+    {file = "yarl-1.13.1-cp310-cp310-win_amd64.whl", hash = "sha256:1bbb418f46c7f7355084833051701b2301092e4611d9e392360c3ba2e3e69f88"},
+    {file = "yarl-1.13.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:216a6785f296169ed52cd7dcdc2612f82c20f8c9634bf7446327f50398732a51"},
+    {file = "yarl-1.13.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:40c6e73c03a6befb85b72da213638b8aaa80fe4136ec8691560cf98b11b8ae6e"},
+    {file = "yarl-1.13.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2430cf996113abe5aee387d39ee19529327205cda975d2b82c0e7e96e5fdabdc"},
+    {file = "yarl-1.13.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9fb4134cc6e005b99fa29dbc86f1ea0a298440ab6b07c6b3ee09232a3b48f495"},
+    {file = "yarl-1.13.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:309c104ecf67626c033845b860d31594a41343766a46fa58c3309c538a1e22b2"},
+    {file = "yarl-1.13.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f90575e9fe3aae2c1e686393a9689c724cd00045275407f71771ae5d690ccf38"},
+    {file = "yarl-1.13.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9d2e1626be8712333a9f71270366f4a132f476ffbe83b689dd6dc0d114796c74"},
+    {file = "yarl-1.13.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5b66c87da3c6da8f8e8b648878903ca54589038a0b1e08dde2c86d9cd92d4ac9"},
+    {file = "yarl-1.13.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:cf1ad338620249f8dd6d4b6a91a69d1f265387df3697ad5dc996305cf6c26fb2"},
+    {file = "yarl-1.13.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:9915300fe5a0aa663c01363db37e4ae8e7c15996ebe2c6cce995e7033ff6457f"},
+    {file = "yarl-1.13.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:703b0f584fcf157ef87816a3c0ff868e8c9f3c370009a8b23b56255885528f10"},
+    {file = "yarl-1.13.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:1d8e3ca29f643dd121f264a7c89f329f0fcb2e4461833f02de6e39fef80f89da"},
+    {file = "yarl-1.13.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:7055bbade838d68af73aea13f8c86588e4bcc00c2235b4b6d6edb0dbd174e246"},
+    {file = "yarl-1.13.1-cp311-cp311-win32.whl", hash = "sha256:a3442c31c11088e462d44a644a454d48110f0588de830921fd201060ff19612a"},
+    {file = "yarl-1.13.1-cp311-cp311-win_amd64.whl", hash = "sha256:81bad32c8f8b5897c909bf3468bf601f1b855d12f53b6af0271963ee67fff0d2"},
+    {file = "yarl-1.13.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:f452cc1436151387d3d50533523291d5f77c6bc7913c116eb985304abdbd9ec9"},
+    {file = "yarl-1.13.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9cec42a20eae8bebf81e9ce23fb0d0c729fc54cf00643eb251ce7c0215ad49fe"},
+    {file = "yarl-1.13.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d959fe96e5c2712c1876d69af0507d98f0b0e8d81bee14cfb3f6737470205419"},
+    {file = "yarl-1.13.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b8c837ab90c455f3ea8e68bee143472ee87828bff19ba19776e16ff961425b57"},
+    {file = "yarl-1.13.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:94a993f976cdcb2dc1b855d8b89b792893220db8862d1a619efa7451817c836b"},
+    {file = "yarl-1.13.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2b2442a415a5f4c55ced0fade7b72123210d579f7d950e0b5527fc598866e62c"},
+    {file = "yarl-1.13.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3fdbf0418489525231723cdb6c79e7738b3cbacbaed2b750cb033e4ea208f220"},
+    {file = "yarl-1.13.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6b7f6e699304717fdc265a7e1922561b02a93ceffdaefdc877acaf9b9f3080b8"},
+    {file = "yarl-1.13.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bcd5bf4132e6a8d3eb54b8d56885f3d3a38ecd7ecae8426ecf7d9673b270de43"},
+    {file = "yarl-1.13.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:2a93a4557f7fc74a38ca5a404abb443a242217b91cd0c4840b1ebedaad8919d4"},
+    {file = "yarl-1.13.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:22b739f99c7e4787922903f27a892744189482125cc7b95b747f04dd5c83aa9f"},
+    {file = "yarl-1.13.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:2db874dd1d22d4c2c657807562411ffdfabec38ce4c5ce48b4c654be552759dc"},
+    {file = "yarl-1.13.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4feaaa4742517eaceafcbe74595ed335a494c84634d33961214b278126ec1485"},
+    {file = "yarl-1.13.1-cp312-cp312-win32.whl", hash = "sha256:bbf9c2a589be7414ac4a534d54e4517d03f1cbb142c0041191b729c2fa23f320"},
+    {file = "yarl-1.13.1-cp312-cp312-win_amd64.whl", hash = "sha256:d07b52c8c450f9366c34aa205754355e933922c79135125541daae6cbf31c799"},
+    {file = "yarl-1.13.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:95c6737f28069153c399d875317f226bbdea939fd48a6349a3b03da6829fb550"},
+    {file = "yarl-1.13.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:cd66152561632ed4b2a9192e7f8e5a1d41e28f58120b4761622e0355f0fe034c"},
+    {file = "yarl-1.13.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6a2acde25be0cf9be23a8f6cbd31734536a264723fca860af3ae5e89d771cd71"},
+    {file = "yarl-1.13.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9a18595e6a2ee0826bf7dfdee823b6ab55c9b70e8f80f8b77c37e694288f5de1"},
+    {file = "yarl-1.13.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a31d21089894942f7d9a8df166b495101b7258ff11ae0abec58e32daf8088813"},
+    {file = "yarl-1.13.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:45f209fb4bbfe8630e3d2e2052535ca5b53d4ce2d2026bed4d0637b0416830da"},
+    {file = "yarl-1.13.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f722f30366474a99745533cc4015b1781ee54b08de73260b2bbe13316079851"},
+    {file = "yarl-1.13.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f3bf60444269345d712838bb11cc4eadaf51ff1a364ae39ce87a5ca8ad3bb2c8"},
+    {file = "yarl-1.13.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:942c80a832a79c3707cca46bd12ab8aa58fddb34b1626d42b05aa8f0bcefc206"},
+    {file = "yarl-1.13.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:44b07e1690f010c3c01d353b5790ec73b2f59b4eae5b0000593199766b3f7a5c"},
+    {file = "yarl-1.13.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:396e59b8de7e4d59ff5507fb4322d2329865b909f29a7ed7ca37e63ade7f835c"},
+    {file = "yarl-1.13.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3bb83a0f12701c0b91112a11148b5217617982e1e466069d0555be9b372f2734"},
+    {file = "yarl-1.13.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c92b89bffc660f1274779cb6fbb290ec1f90d6dfe14492523a0667f10170de26"},
+    {file = "yarl-1.13.1-cp313-cp313-win32.whl", hash = "sha256:269c201bbc01d2cbba5b86997a1e0f73ba5e2f471cfa6e226bcaa7fd664b598d"},
+    {file = "yarl-1.13.1-cp313-cp313-win_amd64.whl", hash = "sha256:1d0828e17fa701b557c6eaed5edbd9098eb62d8838344486248489ff233998b8"},
+    {file = "yarl-1.13.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:8be8cdfe20787e6a5fcbd010f8066227e2bb9058331a4eccddec6c0db2bb85b2"},
+    {file = "yarl-1.13.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:08d7148ff11cb8e886d86dadbfd2e466a76d5dd38c7ea8ebd9b0e07946e76e4b"},
+    {file = "yarl-1.13.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:4afdf84610ca44dcffe8b6c22c68f309aff96be55f5ea2fa31c0c225d6b83e23"},
+    {file = "yarl-1.13.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d0d12fe78dcf60efa205e9a63f395b5d343e801cf31e5e1dda0d2c1fb618073d"},
+    {file = "yarl-1.13.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:298c1eecfd3257aa16c0cb0bdffb54411e3e831351cd69e6b0739be16b1bdaa8"},
+    {file = "yarl-1.13.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c14c16831b565707149c742d87a6203eb5597f4329278446d5c0ae7a1a43928e"},
+    {file = "yarl-1.13.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5a9bacedbb99685a75ad033fd4de37129449e69808e50e08034034c0bf063f99"},
+    {file = "yarl-1.13.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:658e8449b84b92a4373f99305de042b6bd0d19bf2080c093881e0516557474a5"},
+    {file = "yarl-1.13.1-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:373f16f38721c680316a6a00ae21cc178e3a8ef43c0227f88356a24c5193abd6"},
+    {file = "yarl-1.13.1-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:45d23c4668d4925688e2ea251b53f36a498e9ea860913ce43b52d9605d3d8177"},
+    {file = "yarl-1.13.1-cp38-cp38-musllinux_1_2_ppc64le.whl", hash = "sha256:f7917697bcaa3bc3e83db91aa3a0e448bf5cde43c84b7fc1ae2427d2417c0224"},
+    {file = "yarl-1.13.1-cp38-cp38-musllinux_1_2_s390x.whl", hash = "sha256:5989a38ba1281e43e4663931a53fbf356f78a0325251fd6af09dd03b1d676a09"},
+    {file = "yarl-1.13.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:11b3ca8b42a024513adce810385fcabdd682772411d95bbbda3b9ed1a4257644"},
+    {file = "yarl-1.13.1-cp38-cp38-win32.whl", hash = "sha256:dcaef817e13eafa547cdfdc5284fe77970b891f731266545aae08d6cce52161e"},
+    {file = "yarl-1.13.1-cp38-cp38-win_amd64.whl", hash = "sha256:7addd26594e588503bdef03908fc207206adac5bd90b6d4bc3e3cf33a829f57d"},
+    {file = "yarl-1.13.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:a0ae6637b173d0c40b9c1462e12a7a2000a71a3258fa88756a34c7d38926911c"},
+    {file = "yarl-1.13.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:576365c9f7469e1f6124d67b001639b77113cfd05e85ce0310f5f318fd02fe85"},
+    {file = "yarl-1.13.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:78f271722423b2d4851cf1f4fa1a1c4833a128d020062721ba35e1a87154a049"},
+    {file = "yarl-1.13.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9d74f3c335cfe9c21ea78988e67f18eb9822f5d31f88b41aec3a1ec5ecd32da5"},
+    {file = "yarl-1.13.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1891d69a6ba16e89473909665cd355d783a8a31bc84720902c5911dbb6373465"},
+    {file = "yarl-1.13.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fb382fd7b4377363cc9f13ba7c819c3c78ed97c36a82f16f3f92f108c787cbbf"},
+    {file = "yarl-1.13.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c8854b9f80693d20cec797d8e48a848c2fb273eb6f2587b57763ccba3f3bd4b"},
+    {file = "yarl-1.13.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bbf2c3f04ff50f16404ce70f822cdc59760e5e2d7965905f0e700270feb2bbfc"},
+    {file = "yarl-1.13.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:fb9f59f3848edf186a76446eb8bcf4c900fe147cb756fbbd730ef43b2e67c6a7"},
+    {file = "yarl-1.13.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:ef9b85fa1bc91c4db24407e7c4da93a5822a73dd4513d67b454ca7064e8dc6a3"},
+    {file = "yarl-1.13.1-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:098b870c18f1341786f290b4d699504e18f1cd050ed179af8123fd8232513424"},
+    {file = "yarl-1.13.1-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:8c723c91c94a3bc8033dd2696a0f53e5d5f8496186013167bddc3fb5d9df46a3"},
+    {file = "yarl-1.13.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:44a4c40a6f84e4d5955b63462a0e2a988f8982fba245cf885ce3be7618f6aa7d"},
+    {file = "yarl-1.13.1-cp39-cp39-win32.whl", hash = "sha256:84bbcdcf393139f0abc9f642bf03f00cac31010f3034faa03224a9ef0bb74323"},
+    {file = "yarl-1.13.1-cp39-cp39-win_amd64.whl", hash = "sha256:fc2931ac9ce9c61c9968989ec831d3a5e6fcaaff9474e7cfa8de80b7aff5a093"},
+    {file = "yarl-1.13.1-py3-none-any.whl", hash = "sha256:6a5185ad722ab4dd52d5fb1f30dcc73282eb1ed494906a92d1a228d3f89607b0"},
+    {file = "yarl-1.13.1.tar.gz", hash = "sha256:ec8cfe2295f3e5e44c51f57272afbd69414ae629ec7c6b27f5a410efc78b70a0"},
 ]
 
 [package.dependencies]
@@ -2928,12 +3060,13 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 type = ["pytest-mypy"]
 
 [extras]
-all = ["aiobotocore", "aiomcache", "redis"]
+all = ["aiobotocore", "aiomcache", "redis", "valkey"]
 dynamodb = ["aiobotocore"]
 memcache = ["aiomcache"]
 redis = ["redis"]
+valkey = ["valkey"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "77643cd3f90f01bfbec41b9815d3d935129ee563952c3b04d20daf216dd3ee23"
+content-hash = "734c9905cc010ab3c86e0b80babc0c07dfceebd306deec4059f18637eeaadb6f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [tool.poetry]
 name = "fastapi-cache2"
-version = "0.2.2"
+version = "0.3.0"
 description = "Cache for FastAPI"
-authors = ["long2ice <long2ice@gmail.com>"]
+authors = ["long2ice <long2ice@gmail.com>", "Gary Gale <gary@vicchi.org>"]
 license = "Apache-2.0"
 readme = "README.md"
 homepage = "https://github.com/long2ice/fastapi-cache"
@@ -24,6 +24,7 @@ pendulum = "^3.0.0"
 aiomcache = { version = "^0.8.2", optional = true }
 aiobotocore = {version = "^2.13.1", optional = true}
 redis = {version = "^5.0.8", extras = ["redis"]}
+valkey = {version = "^6.0.2", extras = ["libvalkey"]}
 
 [tool.poetry.group.linting]
 optional = true
@@ -53,7 +54,8 @@ twine = { version = "^4.0.2", python = "^3.10" }
 redis = ["redis"]
 memcache = ["aiomcache"]
 dynamodb = ["aiobotocore"]
-all = ["redis", "aiomcache", "aiobotocore"]
+valkey = ["valkey"]
+all = ["redis", "aiomcache", "aiobotocore", "valkey"]
 
 [tool.mypy]
 files = ["."]


### PR DESCRIPTION
Since Valkey was forked from Redis it remains API compatible with Redis. For now. But there's much activity and progress going on with Valkey, including support in the Python client for using `libvalkey` for better cache performance.