### PR TITLE
fix: .clear method generates namespace even if key is passed

### DIFF
--- a/fastapi_cache/__init__.py
+++ b/fastapi_cache/__init__.py
@@ -99,5 +99,6 @@ class FastAPICache:
         assert (  # noqa: S101
             cls._backend and cls._prefix is not None
         ), "You must call init first!"
-        namespace = cls._prefix + (":" + namespace if namespace else "")
+        if namespace is not None or key is None:
+            namespace = cls._prefix + (":" + namespace if namespace else "")
         return await cls._backend.clear(namespace, key)


### PR DESCRIPTION
Fixes #451 

calling 
```python
FastAPICache.clear(key="value")
```
method generates 
```python
namespace = cls._prefix + (":" + namespace if namespace else "")
```
even if key is passed. It then goes to 
```python
cls._backend.clear(namespace, key)
```
where key is never used because of this if-else statement:
```python
if namespace:
    lua = f"for i, name in ipairs(redis.call('KEYS', '{namespace}:*')) do redis.call('DEL', name); end"
    return await self.redis.eval(lua, numkeys=0)  # type: ignore[union-attr,no-any-return]
elif key:
    return await self.redis.delete(key)  # type: ignore[union-attr]
return 0
```
Same for inmemory backend realisation.

With proposed changes clearing cache by key will work correctly, without clearing whole namespace