### PR TITLE
fix: recognize POST method as cacheable

### DIFF
--- a/fastapi_cache/decorator.py
+++ b/fastapi_cache/decorator.py
@@ -79,7 +79,7 @@ def _uncacheable(request: Optional[Request]) -> bool:
         return True
     if request is None:
         return False
-    if request.method != "GET":
+    if request.method not in ["GET", "POST"]:
         return True
     return request.headers.get("Cache-Control") == "no-store"
 

--- a/fastapi_cache/decorator.py
+++ b/fastapi_cache/decorator.py
@@ -71,7 +71,7 @@ def _uncacheable(request: Optional[Request]) -> bool:
 
     Returns true if:
     - Caching has been disabled globally
-    - This is not a GET request
+    - This is not a GET or POST request
     - The request has a Cache-Control header with a value of "no-store"
 
     """


### PR DESCRIPTION
### Description

I am using `fastapi-cache` for my project and encountered a small issue regarding request caching. Currently, the `_uncachable` function allows caching only for `GET` requests, and I would like to propose allowing `POST` requests as well.

### Use Case
In my setup, I use a Bastion Host to receive user requests and forward them to the actual server. To reduce unnecessary computations, I want to cache responses for `POST` requests when the same input is provided multiple times. There are cases where multiple identical requests are sent in a short period, and caching can help prevent redundant processing. However, since `_uncachable` restricts caching to `GET` requests, I am unable to achieve this with the current implementation.
Allowing caching for POST requests could be useful when performing idempotent operations based on the user's request.

### Proposed Change
I modified the code to allow caching for `POST` requests and confirmed that it works correctly. If there are no other logical issues, would it be possible to consider making this behavior configurable or allowing caching for `POST` requests under certain conditions?


Looking forward to your thoughts. Thanks!