### PR TITLE
fix delete cache by key when namespace is not provided

### DIFF
--- a/fastapi_cache/backends/redis.py
+++ b/fastapi_cache/backends/redis.py
@@ -22,7 +22,7 @@ class RedisBackend(Backend):
         await self.redis.set(key, value, ex=expire)  # type: ignore[union-attr]
 
     async def clear(self, namespace: Optional[str] = None, key: Optional[str] = None) -> int:
-        if namespace:
+        if namespace and not namespace.strip():
             lua = f"for i, name in ipairs(redis.call('KEYS', '{namespace}:*')) do redis.call('DEL', name); end"
             return await self.redis.eval(lua, numkeys=0)  # type: ignore[union-attr,no-any-return]
         elif key:


### PR DESCRIPTION
when deleting cache by key, RedisBackend will delete all the cache. Because namespace always is "" so the elif satement will never be executed