### PR TITLE
fix delete cache by key when namespace is not provided

### DIFF
--- a/fastapi_cache/__init__.py
+++ b/fastapi_cache/__init__.py
@@ -99,5 +99,6 @@ class FastAPICache:
         assert (  # noqa: S101
             cls._backend and cls._prefix is not None
         ), "You must call init first!"
-        namespace = cls._prefix + (":" + namespace if namespace else "")
+        if namespace and namespace.strip() != "":
+            namespace = cls._prefix + ":" + namespace
         return await cls._backend.clear(namespace, key)


### PR DESCRIPTION
when deleting cache by key, RedisBackend will delete all the cache. Because namespace always is "" so the elif satement will never be executed