### PR TITLE
fix: use deterministic hash for ETag generation

### DIFF
--- a/fastapi_cache/decorator.py
+++ b/fastapi_cache/decorator.py
@@ -1,3 +1,4 @@
+import hashlib
 import logging
 import sys
 from functools import wraps
@@ -64,6 +65,16 @@ def _locate_param(
         to_inject.append(dep)
         param = dep
     return param
+
+
+def _compute_etag(data: bytes) -> str:
+    """Compute a deterministic ETag hash from cache data.
+
+    Uses MD5 for speed since this is for caching, not security.
+    Unlike Python's built-in hash(), this produces consistent values
+    across different processes and service restarts.
+    """
+    return hashlib.md5(data).hexdigest()
 
 
 def _uncacheable(request: Optional[Request]) -> bool:
@@ -199,14 +210,14 @@ def cache(
                     response.headers.update(
                         {
                             "Cache-Control": f"max-age={expire}",
-                            "ETag": f"W/{hash(to_cache)}",
+                            "ETag": f"W/{_compute_etag(to_cache)}",
                             cache_status_header: "MISS",
                         }
                     )
 
             else:  # cache hit
                 if response:
-                    etag = f"W/{hash(cached)}"
+                    etag = f"W/{_compute_etag(cached)}"
                     response.headers.update(
                         {
                             "Cache-Control": f"max-age={ttl}",


### PR DESCRIPTION
## Summary

Fixes #400

Python's built-in `hash()` function is salted by default (via `PYTHONHASHSEED`), which means it produces different values:
- Across different Python processes
- After service restart
- Between multiple backends behind a load balancer

This causes ETags to change unexpectedly, invalidating browser caches and making the cache mechanism effectively useless in distributed deployments.

## Changes

Replace `hash()` with `hashlib.md5()` for ETag generation:

```python
def _compute_etag(data: bytes) -> str:
    """Compute a deterministic ETag hash from cache data."""
    return hashlib.md5(data).hexdigest()
```

MD5 is chosen for speed since this is for caching (not security). The hash is consistent across processes and restarts.

## Before/After

Before (unpredictable across processes):
```
ETag: W/-4586327899234  # Process 1
ETag: W/8923847234987   # Process 2 (same data, different hash)
```

After (deterministic):
```
ETag: W/d41d8cd98f00b204e9800998ecf8427e  # Process 1
ETag: W/d41d8cd98f00b204e9800998ecf8427e  # Process 2 (same data, same hash)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)