### PR TITLE
Declare jinja2 as a direct dependency

### DIFF
--- a/changelog.d/568.bugfix.md
+++ b/changelog.d/568.bugfix.md
@@ -1,0 +1,1 @@
+Declare `jinja2` as a direct dependency. `fastapi_cache.coder` imports `starlette.templating` unconditionally, which requires jinja2, but jinja2 is only an optional starlette extra (dropped from the base install in Starlette 1.0). This fixes `ImportError: jinja2 must be installed to use Jinja2Templates` on a minimal install.

--- a/poetry.lock
+++ b/poetry.lock
@@ -314,8 +314,8 @@ files = [
 jmespath = ">=0.7.1,<2.0.0"
 python-dateutil = ">=2.1,<3.0.0"
 urllib3 = [
-    {version = ">=1.25.4,<2.2.0 || >2.2.0,<3", markers = "python_version >= \"3.10\""},
     {version = ">=1.25.4,<1.27", markers = "python_version < \"3.10\""},
+    {version = ">=1.25.4,<2.2.0 || >2.2.0,<3", markers = "python_version >= \"3.10\""},
 ]
 
 [package.extras]
@@ -1649,8 +1649,8 @@ files = [
 annotated-types = ">=0.6.0"
 pydantic-core = "2.23.4"
 typing-extensions = [
-    {version = ">=4.12.2", markers = "python_version >= \"3.13\""},
     {version = ">=4.6.1", markers = "python_version < \"3.13\""},
+    {version = ">=4.12.2", markers = "python_version >= \"3.13\""},
 ]
 
 [package.extras]
@@ -2936,4 +2936,4 @@ redis = ["redis"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "77643cd3f90f01bfbec41b9815d3d935129ee563952c3b04d20daf216dd3ee23"
+content-hash = "41d4808cb0769702d388f4c572fb27437644b905ae2b69b31f2de7d9140c246f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,10 @@ uvicorn = "*"
 typing-extensions = { version = ">=4.1.0" }
 importlib-metadata = { version = "^6.6.0", python = "<3.8" }
 pendulum = "^3.0.0"
+# coder.py imports starlette.templating unconditionally, which requires jinja2.
+# jinja2 is only an optional starlette extra (dropped from the base install in
+# Starlette 1.0), so declare it explicitly here.
+jinja2 = "*"
 aiomcache = { version = "^0.8.2", optional = true }
 aiobotocore = {version = "^2.13.1", optional = true}
 redis = {version = "^5.0.8", extras = ["redis"]}


### PR DESCRIPTION
`fastapi_cache.coder` imports `starlette.templating` unconditionally, which requires `jinja2`. Since Starlette 1.0 no longer bundles `jinja2` (it's an optional extra), a minimal install crashes with 'ImportError: jinja2 must be installed to use Jinja2Templates'. The test suite missed this because the dev group pulls in `jinja2` transitively via `towncrier`.

Fixes #568

Note: this slipped past CI because the test env installs the `dev` group (→ `towncrier` → `jinja2`), so `jinja2` is always incidentally present during tests. A CI job that `pip install`s the built wheel into a clean venv and runs `python -c "import fastapi_cache"` would catch this and any future undeclared runtime dep. I'm also happy to contribute it if you're interested.